### PR TITLE
【feature】ER図追加 close #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # ER図
 詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)
-![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/d3f90a87-f014-4804-b5cf-d635401295a8)
+![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/a0308fcf-9847-4293-bf33-191eaf9161f6)

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # ER図
 詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)
-![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/dd643cfc-1f0d-481b-b802-4fc68b5bd5de)
+![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/9cfcd0ca-e802-4353-be91-60d2168c2570)

--- a/README.md
+++ b/README.md
@@ -89,3 +89,6 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # 画面遷移図
 画面遷移図は[こちら](https://www.figma.com/file/Z8BLQOGYOCx1tB3gs7YeM9/Astoryer-%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?type=design&node-id=0%3A1&mode=design&t=N3XTulFLnkgiPiJh-1)
+
+# ER図
+詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # ER図
 詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)
-![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/9cfcd0ca-e802-4353-be91-60d2168c2570)
+<img src="https://github.com/topi0247/Project-AStoryer/assets/23026318/06ed92fc-af11-45a8-9a05-92ab834f169c" width="500px" />

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # ER図
 詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)
-![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/a0308fcf-9847-4293-bf33-191eaf9161f6)
+![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/dd643cfc-1f0d-481b-b802-4fc68b5bd5de)

--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ TRPGで遊んだユーザーの中には、自分のPC、あるいは一緒に�
 
 # ER図
 詳細は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)
+![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/d3f90a87-f014-4804-b5cf-d635401295a8)


### PR DESCRIPTION
# 概要
本アプリのテーブル設計を行い、ER図を作成しました。
READMEにて詳細画面へのリンクと画像を追加しております。

## ER図内容
READMEと同じものになりますが以下のとおりです。
ER図はdbdiagramというサービスを利用しております。そちらから見る場合は[こちら](https://dbdiagram.io/d/AStoryer-6609892837b7e33fd7263f64)からご覧いただけます。
![ER図](https://github.com/topi0247/Project-AStoryer/assets/23026318/d3f90a87-f014-4804-b5cf-d635401295a8)

### 補足
- userテーブルはdeviseを利用して作成予定です。
- user_noticesにあるnotice_typeはアプリ内通知やメール通知など種類があることからその区別のためのカラムです。
- 通知項目は「いいねがあったら」「ブクマがあったら」「コメントがあったら」「フォローされたら」です。
- user_linksにあるlink_typeはXなど本アプリ側からあらかじめ設定できるリンクの他に、other項目として自由にリンクを追加できるようにしています。
- 上記につきlinksテーブルにはあらかじめ設定できるリンクの場合はaccount_idを、自由追加の場合はurlを追加するように設定しています。
- view_countsは閲覧数テーブルです。
- postsテーブル（投稿データ）は今後イラスト投稿以外に小説投稿を検討していることから、illustsを別テーブルに切り分けています。

### 疑問点
リンクテーブルにてアカウントidとurlのカラムを分けています。
こちらたとえばbodyなどの命名で統一すべきでしょうか？
カラムの内容としては切り分けたほうが良いと思う一方、2つのカラムが同時に埋まることは想定外なので統一してしまってもよいのではないかとも考えております。
よろしければご意見うかがえれば幸いです。

上記ご確認のほど、よろしくお願いいたします。
