### PR TITLE
【feature】フッター作成 close #25

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -11,5 +11,11 @@
     "searchPlaceholder": "タグやシナリオ名で検索",
     "searchButton": "検索",
     "postButton": "作品を投稿"
+  },
+  "Footer": {
+    "about": "AStoryerとは",
+    "termsOfService": "利用規約",
+    "privacyPolicy": "プライバシーポリシー",
+    "contact": "お問い合わせ"
   }
 }

--- a/front/src/app/[locale]/about/page.tsx
+++ b/front/src/app/[locale]/about/page.tsx
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <div>アバウトページ</div>;
+}

--- a/front/src/app/[locale]/contact/page.tsx
+++ b/front/src/app/[locale]/contact/page.tsx
@@ -1,0 +1,3 @@
+export default function ContactPage() {
+  return <div>お問い合わせ</div>;
+}

--- a/front/src/app/[locale]/layout.tsx
+++ b/front/src/app/[locale]/layout.tsx
@@ -18,11 +18,14 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <NextIntlClientProvider locale={locale} messages={messages}>
-        <body className="w-screen min-h-screen flex flex-col bg-slate-200">
+        <body className="w-screen min-h-screen flex flex-col bg-slate-200 relative">
           <div className="w-full bg-white shadow-sm">
             <Layout.Headers />
           </div>
-          {children}
+          <main className="w-full flex-1">{children}</main>
+          <div className="w-full bg-slate-500">
+            <Layout.Footers />
+          </div>
         </body>
       </NextIntlClientProvider>
     </html>

--- a/front/src/components/layouts/footers.tsx
+++ b/front/src/components/layouts/footers.tsx
@@ -1,30 +1,50 @@
 import { Link } from "@/lib";
+import { useTranslations } from "next-intl";
 
 export default function Footers() {
+  const t_Footer = useTranslations("Footer");
   return (
-    <footer className="flex text-white justify-between items-center w-full py-8">
-      <div className="ml-8 text-2xl">
-        <h3 className="text-center m-auto">
+    <footer className="p-4 flex text-white justify-between md:items-center w-full md:py-8">
+      <div className="flex flex-col gap-3 md:block md:gap-0 text-2xl md:ml-8">
+        <h3 className="md:text-center md:m-auto">
           <Link href="/" className="flex flex-col">
-            AStoryer <span>- あすとりや -</span>
+            AStoryer <span className="text-sm">- あすとりや -</span>
           </Link>
         </h3>
+        <p className="md:hidden text-sm">©2024 AStoryer -あすとりや-</p>
       </div>
-      <section className="mr-8 flex flex-col gap-3">
+      <section className="text-sm md:text-normal md:mr-8 md:flex md:flex-col md:gap-3">
         <nav>
-          <ul className="flex gap-3">
+          <ul className="flex flex-col gap-1 md:gap-3 md:flex-row">
             <li>
-              <Link href="/terms-of-service">利用規約</Link>
+              <Link href="/about" className="hover:opacity-80 transition-all">
+                {t_Footer("about")}
+              </Link>
             </li>
             <li>
-              <Link href="/privacy-policy">プライバシーポリシー</Link>
+              <Link
+                href="/terms-of-service"
+                className="hover:opacity-80 transition-all"
+              >
+                {t_Footer("termsOfService")}
+              </Link>
             </li>
             <li>
-              <Link href="/contact">お問い合わせ</Link>
+              <Link
+                href="/privacy-policy"
+                className="hover:opacity-80 transition-all"
+              >
+                {t_Footer("privacyPolicy")}
+              </Link>
+            </li>
+            <li>
+              <Link href="/contact" className="hover:opacity-80 transition-all">
+                {t_Footer("contact")}
+              </Link>
             </li>
           </ul>
         </nav>
-        <p>©2024 AStoryer -あすとりや-</p>
+        <p className="hidden md:block">©2024 AStoryer -あすとりや-</p>
       </section>
     </footer>
   );

--- a/front/src/components/layouts/footers.tsx
+++ b/front/src/components/layouts/footers.tsx
@@ -1,0 +1,31 @@
+import { Link } from "@/lib";
+
+export default function Footers() {
+  return (
+    <footer className="flex text-white justify-between items-center w-full py-8">
+      <div className="ml-8 text-2xl">
+        <h3 className="text-center m-auto">
+          <Link href="/" className="flex flex-col">
+            AStoryer <span>- あすとりや -</span>
+          </Link>
+        </h3>
+      </div>
+      <section className="mr-8 flex flex-col gap-3">
+        <nav>
+          <ul className="flex gap-3">
+            <li>
+              <Link href="/terms-of-service">利用規約</Link>
+            </li>
+            <li>
+              <Link href="/privacy-policy">プライバシーポリシー</Link>
+            </li>
+            <li>
+              <Link href="/contact">お問い合わせ</Link>
+            </li>
+          </ul>
+        </nav>
+        <p>©2024 AStoryer -あすとりや-</p>
+      </section>
+    </footer>
+  );
+}

--- a/front/src/components/layouts/index.ts
+++ b/front/src/components/layouts/index.ts
@@ -1,3 +1,4 @@
 import Headers from "./headers";
+import Footers from "./footers";
 
-export { Headers };
+export { Headers, Footers };


### PR DESCRIPTION
# 概要
フッターを実装しました。スマホ対応済みです。

## 実装内容
- [x] 左下にロゴが表示される
- [x] ロゴをクリックすると一覧ページへ遷移する
⇨ホームページへ遷移
- [x] 利用規約をクリックすると利用規約のページへ遷移する
- [x] プライバシーポリシーをクリックするとプライバシーポリシーのページへ遷移する
- [x] お問い合わせページをクリックするとお問い合わせページへ遷移する
- [x] AStoryerとはをクリックすると、abautoページに遷移する

## 実装状況
PC版
[![Image from Gyazo](https://i.gyazo.com/2cc9e4d1fa6bf191271cf106c4a6f766.png)](https://gyazo.com/2cc9e4d1fa6bf191271cf106c4a6f766)
SP版
[![Image from Gyazo](https://i.gyazo.com/4e1fb3740be3199b23607d8bc823fecd.png)](https://gyazo.com/4e1fb3740be3199b23607d8bc823fecd)

## 補足
当初の緑色だと、プライマリーカラーとして使われており主張が激しくなってしまうため色を変更しました。