### PR TITLE
【feature】新規登録ページ・モーダル作成 close #13

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -17,5 +17,21 @@
     "termsOfService": "利用規約",
     "privacyPolicy": "プライバシーポリシー",
     "contact": "お問い合わせ"
+  },
+  "Auth": {
+    "name": "名前",
+    "email": "メールアドレス",
+    "password": "パスワード",
+    "password_confirmation": "パスワード（確認）",
+    "login": "ログイン",
+    "signup": "新規登録",
+    "signup_with_google": "Googleで登録",
+    "signup_with_discord": "Discordで登録",
+    "to_login": "ログインはこちら",
+    "or": "または",
+    "invalidEmail": "メールアドレスの形式で入力してください",
+    "invalidPassword": "6文字以上で入力してください",
+    "invalidPasswordConfirmation": "パスワードが一致しません",
+    "required": "必須項目です"
   }
 }

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -28,10 +28,12 @@
     "signup_with_google": "Googleで登録",
     "signup_with_discord": "Discordで登録",
     "to_login": "ログインはこちら",
+    "to_signup": "新規登録はこちら",
     "or": "または",
     "invalidEmail": "メールアドレスの形式で入力してください",
     "invalidPassword": "6文字以上で入力してください",
     "invalidPasswordConfirmation": "パスワードが一致しません",
-    "required": "必須項目です"
+    "required": "必須項目です",
+    "requiredAuth": "この機能はログインが必要です"
   }
 }

--- a/front/src/app/[locale]/layout.tsx
+++ b/front/src/app/[locale]/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import "@/app/globals.css";
-import * as Layout from "@/components/layouts";
 import { NextIntlClientProvider, useMessages } from "next-intl";
+import AppProvider from "@/providers/index";
+import { MainLayout } from "@/components/layouts";
 
 export const metadata: Metadata = {
   title: "AStoryer - あすとりや -",
@@ -17,17 +18,13 @@ export default function RootLayout({
   const messages = useMessages();
   return (
     <html lang="ja">
-      <NextIntlClientProvider locale={locale} messages={messages}>
-        <body className="w-screen min-h-screen flex flex-col bg-slate-200 relative">
-          <div className="w-full bg-white shadow-sm">
-            <Layout.Headers />
-          </div>
-          <main className="w-full flex-1">{children}</main>
-          <div className="w-full bg-slate-500">
-            <Layout.Footers />
-          </div>
-        </body>
-      </NextIntlClientProvider>
+      <AppProvider>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <body className="w-screen min-h-screen flex flex-col bg-slate-200 relative">
+            <MainLayout>{children}</MainLayout>
+          </body>
+        </NextIntlClientProvider>
+      </AppProvider>
     </html>
   );
 }

--- a/front/src/app/[locale]/signup/page.tsx
+++ b/front/src/app/[locale]/signup/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Button } from "@mui/material";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@/lib";
+import { InputText } from "@/components/form";
+
+interface IFormInputs {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+export default function SignUpPage() {
+  const t_Auth = useTranslations("Auth");
+
+  const { handleSubmit, control, getValues } = useForm<IFormInputs>();
+
+  const onSubmit: SubmitHandler<IFormInputs> = async (data) => {
+    // TODO : 新規登録処理を書く
+  };
+
+  const loginWithGoogle = () => {
+    // TODO : Google新規登録処理を書く
+  };
+
+  const loginWithDiscord = () => {
+    // TODO : Discord新規登録処理を書く
+  };
+
+  return (
+    <>
+      <article className="w-full flex flex-col justify-center items-center mb-8">
+        <section className="flex flex-col justify-center items-center max-w-96 w-full px-8">
+          <h2 className="text-center font-semibold text-xl md:text-2xl my-8">
+            <span className="pb-2 border-b-2 border-green-400 px-4">
+              {t_Auth("signup")}
+            </span>
+          </h2>
+          <div className="flex flex-col gap-2 justify-center items-center w-full bg-white p-4 px-6 rounded">
+            <form
+              className="flex flex-col gap-4 w-full"
+              onSubmit={handleSubmit(onSubmit)}
+            >
+              <InputText
+                control={control}
+                name="name"
+                label={t_Auth("name")}
+                rules={{
+                  required: { value: true, message: t_Auth("required") },
+                }}
+                autoComplete="name"
+              />
+              <InputText
+                control={control}
+                name="email"
+                label={t_Auth("email")}
+                rules={{
+                  required: { value: true, message: t_Auth("required") },
+                  pattern: {
+                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
+                    message: t_Auth("invalidEmail"),
+                  },
+                }}
+                autoComplete="email"
+              />
+              <InputText
+                control={control}
+                name="password"
+                label={t_Auth("password")}
+                type="password"
+                rules={{
+                  required: { value: true, message: t_Auth("required") },
+                  minLength: {
+                    value: 6,
+                    message: t_Auth("invalidPassword"),
+                  },
+                }}
+                autoComplete="new-password"
+              />
+              <InputText
+                control={control}
+                name="passwordConfirmation"
+                label={t_Auth("password_confirmation")}
+                type="password"
+                rules={{
+                  required: { value: true, message: t_Auth("required") },
+                  validate: (value: string) =>
+                    value === getValues("password") ||
+                    t_Auth("invalidPasswordConfirmation"),
+                  minLength: {
+                    value: 6,
+                    message: t_Auth("invalidPassword"),
+                  },
+                }}
+                autoComplete="new-password"
+              />
+              <Button variant="outlined" type="submit">
+                {t_Auth("signup")}
+              </Button>
+            </form>
+            <div className="text-center">
+              <Link
+                href="/login"
+                className="text-center text-sm text-blue-500 underline hover:opacity-50 transition-all"
+              >
+                {t_Auth("to_login")}
+              </Link>
+            </div>
+            <div className="w-full relative h-10">
+              <div className="border-t border-green-400 w-full text-center overflow-visible absolute top-1/2 left-0" />
+              <p className="w-full text-center absolute top-[6px] left-0">
+                <span className="bg-white px-6">{t_Auth("or")}</span>
+              </p>
+            </div>
+            <div className="flex flex-col md:flex-row gap-4">
+              <Button
+                variant="outlined"
+                onClick={loginWithGoogle}
+                sx={{ textTransform: "none" }}
+              >
+                {t_Auth("signup_with_google")}
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={loginWithDiscord}
+                sx={{ textTransform: "none" }}
+              >
+                {t_Auth("signup_with_discord")}
+              </Button>
+            </div>
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/front/src/components/form/index.ts
+++ b/front/src/components/form/index.ts
@@ -1,0 +1,3 @@
+import { InputText } from "./inputText";
+
+export { InputText };

--- a/front/src/components/form/inputText.tsx
+++ b/front/src/components/form/inputText.tsx
@@ -1,0 +1,42 @@
+import { TextField } from "@mui/material";
+import { Controller } from "react-hook-form";
+
+export const InputText = (
+  {
+    control,
+    name,
+    label,
+    rules,
+    type = "text",
+    autoComplete = "",
+  }: {
+    control: any;
+    name: string;
+    label: string;
+    rules: object;
+    type?: string;
+    autoComplete?: string;
+  },
+  {}
+) => {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      defaultValue=""
+      render={({ field, fieldState: { error } }) => (
+        <TextField
+          {...field}
+          label={label}
+          type={type}
+          variant="outlined"
+          autoComplete={autoComplete}
+          error={!!error}
+          helperText={error ? error.message : null}
+          fullWidth
+        />
+      )}
+    />
+  );
+};

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -11,6 +11,7 @@ import * as UI from "@/components/ui";
 
 export default function Headers() {
   const t_Header = useTranslations("Header");
+  const t_Auth = useTranslations("Auth");
   const [search, setSearch] = useState("");
   const router = useRouter();
   const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
@@ -75,19 +76,19 @@ export default function Headers() {
         </div>
       </header>
       <UI.Modal>
-        <p className="text-center">この機能はログインが必要です。</p>
+        <p className="text-center">{t_Auth("requiredAuth")}</p>
         <div className="flex gap-4 justify-center items-center mt-4 w-68 m-auto">
           <button
             onClick={() => handleRequired("signup")}
             className="text-blue-300 underline hover:opacity-80 transition-all"
           >
-            新規登録はこちら
+            {t_Auth("to_signup")}
           </button>
           <button
             onClick={() => handleRequired("login")}
             className="text-blue-300 underline hover:opacity-80 transition-all"
           >
-            ログインはこちら
+            {t_Auth("to_login")}
           </button>
         </div>
       </UI.Modal>

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -1,32 +1,37 @@
 "use client";
 import { Link, useRouter } from "@/lib";
-import {
-  Search,
-  AccountCircle,
-  Bookmark,
-  Settings,
-  Logout,
-} from "@mui/icons-material";
+import * as RecoilState from "@/recoilState";
+import * as MUI_ICONS from "@mui/icons-material";
 import MenuIcon from "@mui/icons-material/Menu";
-import {
-  Avatar,
-  Box,
-  IconButton,
-  ListItemIcon,
-  Menu,
-  MenuItem,
-  Tooltip,
-} from "@mui/material";
+import * as MUI from "@mui/material";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { useSetRecoilState } from "recoil";
+import * as UI from "@/components/ui";
 
 export default function Headers() {
   const t_Header = useTranslations("Header");
   const [search, setSearch] = useState("");
+  const router = useRouter();
+  const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
+  const setModalTitle = useSetRecoilState(RecoilState.modalTitleState);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     // TODO : 検索処理
+  };
+
+  const handlePost = () => {
+    // TODO : ログインユーザーであれば画面遷移する
+    // router.push("/illusts/post");
+    // TODO : ログインユーザーでなければログインや登録を促す
+    setModalOpen(true);
+    setModalTitle("Attention");
+  };
+
+  const handleRequired = (path: string) => {
+    setModalOpen(false);
+    router.push(`/${path}`);
   };
 
   return (
@@ -44,7 +49,7 @@ export default function Headers() {
               onSubmit={handleSearch}
             >
               <label className="bg-green-100 md:p-1 rounded md:text-sm md:flex md:justify-center md:items-center text-gray-400">
-                <Search style={{ margin: "0 2px" }} />
+                <MUI_ICONS.Search style={{ margin: "0 2px" }} />
                 <input
                   type="text"
                   className="bg-green-100 focus:outline-none w-60 text-black"
@@ -60,15 +65,32 @@ export default function Headers() {
               </button>
             </form>
           </div>
-          <Link
-            href="/illusts/post"
+          <button
+            onClick={handlePost}
             className="hidden md:block bg-orange-100 px-2 py-1 rounded hover:bg-orange-300 transition-all"
           >
             {t_Header("postButton")}
-          </Link>
+          </button>
           {AccountMenu()}
         </div>
       </header>
+      <UI.Modal>
+        <p className="text-center">この機能はログインが必要です。</p>
+        <div className="flex gap-4 justify-center items-center mt-4 w-68 m-auto">
+          <button
+            onClick={() => handleRequired("signup")}
+            className="text-blue-300 underline hover:opacity-80 transition-all"
+          >
+            新規登録はこちら
+          </button>
+          <button
+            onClick={() => handleRequired("login")}
+            className="text-blue-300 underline hover:opacity-80 transition-all"
+          >
+            ログインはこちら
+          </button>
+        </div>
+      </UI.Modal>
     </>
   );
 }
@@ -98,9 +120,11 @@ function AccountMenu() {
 
   return (
     <>
-      <Box sx={{ display: "flex", alignItems: "center", textAlign: "center" }}>
-        <Tooltip title="マイメニュー">
-          <IconButton
+      <MUI.Box
+        sx={{ display: "flex", alignItems: "center", textAlign: "center" }}
+      >
+        <MUI.Tooltip title="マイメニュー">
+          <MUI.IconButton
             onClick={handleClick}
             size="small"
             aria-controls={open ? "account-menu" : undefined}
@@ -108,7 +132,7 @@ function AccountMenu() {
             aria-expanded={open ? "true" : undefined}
           >
             <div className="hidden md:block">
-              <Avatar
+              <MUI.Avatar
                 alt="icon"
                 src="https://placehold.jp/300x300.png"
                 sx={{ width: 56, height: 56 }}
@@ -117,10 +141,10 @@ function AccountMenu() {
             <div className="md:hidden m-4">
               <MenuIcon sx={{ width: 32, height: 32 }} />
             </div>
-          </IconButton>
-        </Tooltip>
-      </Box>
-      <Menu
+          </MUI.IconButton>
+        </MUI.Tooltip>
+      </MUI.Box>
+      <MUI.Menu
         anchorEl={anchorEl}
         id="account-menu"
         open={open}
@@ -129,16 +153,16 @@ function AccountMenu() {
         transformOrigin={{ horizontal: "right", vertical: "top" }}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
       >
-        <MenuItem onClick={() => handleLink("users/1")}>
-          <Avatar
+        <MUI.MenuItem onClick={() => handleLink("users/1")}>
+          <MUI.Avatar
             alt="icon"
             src="https://placehold.jp/300x300.png"
             sx={{ width: 56, height: 56 }}
           />{" "}
           <span className="ml-4">ユーザー名</span>
-        </MenuItem>
+        </MUI.MenuItem>
         <div className="flex justify-center items-center">
-          <MenuItem onClick={() => handleLink("#")}>
+          <MUI.MenuItem onClick={() => handleLink("#")}>
             <Link
               href="#"
               className="flex flex-col justify-center items-center"
@@ -146,8 +170,8 @@ function AccountMenu() {
               <span>フォロー</span>
               <span>10人</span>
             </Link>
-          </MenuItem>
-          <MenuItem onClick={() => handleLink("#")}>
+          </MUI.MenuItem>
+          <MUI.MenuItem onClick={() => handleLink("#")}>
             <Link
               href="#"
               className="flex flex-col justify-center items-center"
@@ -155,33 +179,33 @@ function AccountMenu() {
               <span>フォロー</span>
               <span>10人</span>
             </Link>
-          </MenuItem>
+          </MUI.MenuItem>
         </div>
-        <MenuItem onClick={() => handleLink("users/1")}>
-          <ListItemIcon>
-            <AccountCircle fontSize="small" />
-          </ListItemIcon>
+        <MUI.MenuItem onClick={() => handleLink("users/1")}>
+          <MUI.ListItemIcon>
+            <MUI_ICONS.AccountCircle fontSize="small" />
+          </MUI.ListItemIcon>
           マイページ
-        </MenuItem>
-        <MenuItem onClick={() => handleLink("users/1/bookmarks")}>
-          <ListItemIcon>
-            <Bookmark fontSize="small" />
-          </ListItemIcon>
+        </MUI.MenuItem>
+        <MUI.MenuItem onClick={() => handleLink("users/1/bookmarks")}>
+          <MUI.ListItemIcon>
+            <MUI_ICONS.Bookmark fontSize="small" />
+          </MUI.ListItemIcon>
           ブックマーク
-        </MenuItem>
-        <MenuItem onClick={() => handleLink("account/1")}>
-          <ListItemIcon>
-            <Settings fontSize="small" />
-          </ListItemIcon>
+        </MUI.MenuItem>
+        <MUI.MenuItem onClick={() => handleLink("account/1")}>
+          <MUI.ListItemIcon>
+            <MUI_ICONS.Settings fontSize="small" />
+          </MUI.ListItemIcon>
           設定
-        </MenuItem>
-        <MenuItem onClick={handleLogout}>
-          <ListItemIcon>
-            <Logout fontSize="small" />
-          </ListItemIcon>
+        </MUI.MenuItem>
+        <MUI.MenuItem onClick={handleLogout}>
+          <MUI.ListItemIcon>
+            <MUI_ICONS.Logout fontSize="small" />
+          </MUI.ListItemIcon>
           ログアウト
-        </MenuItem>
-      </Menu>
+        </MUI.MenuItem>
+      </MUI.Menu>
     </>
   );
 }

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -34,7 +34,7 @@ export default function Headers() {
       <header className="flex justify-between items-center ml-2 md:mx-8 md:my-2">
         <h1>
           <Link href="/">
-            <img src="logo.png" width={150} />
+            <img src="/logo.png" width={150} />
           </Link>
         </h1>
         <div className="md:flex md:items-center md:justify-center md:gap-8">

--- a/front/src/components/layouts/index.ts
+++ b/front/src/components/layouts/index.ts
@@ -1,4 +1,5 @@
 import Headers from "./headers";
 import Footers from "./footers";
+import MainLayout from "./mainLayout";
 
-export { Headers, Footers };
+export { Headers, Footers, MainLayout };

--- a/front/src/components/layouts/mainLayout.tsx
+++ b/front/src/components/layouts/mainLayout.tsx
@@ -1,0 +1,20 @@
+import Footers from "./footers";
+import Headers from "./headers";
+
+export default function MainLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <div className="w-full bg-white shadow-sm">
+        <Headers />
+      </div>
+      <main className="w-full flex-1">{children}</main>
+      <div className="w-full bg-slate-500">
+        <Footers />
+      </div>
+    </>
+  );
+}

--- a/front/src/components/ui/index.ts
+++ b/front/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+import Modal from "./modal";
+
+export { Modal };

--- a/front/src/components/ui/modal.tsx
+++ b/front/src/components/ui/modal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
+import Fade from "@mui/material/Fade";
+import Typography from "@mui/material/Typography";
+import { useRecoilState, useRecoilValue } from "recoil";
+import * as ModalState from "@/recoilState";
+
+const style = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  boxShadow: 24,
+  p: 4,
+};
+
+export default function TransitionsModal({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useRecoilState(ModalState.modalOpenState);
+  const title = useRecoilValue(ModalState.modalTitleState);
+
+  return (
+    <div>
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={open}
+        onClose={() => setOpen(false)}
+        closeAfterTransition
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 300,
+          },
+        }}
+      >
+        <Fade in={open}>
+          <Box sx={style}>
+            <Typography
+              id="transition-modal-title"
+              variant="h6"
+              component="h2"
+              sx={{ textAlign: "center" }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              id="transition-modal-description"
+              sx={{ mt: 2, mx: "auto" }}
+            >
+              {children}
+            </Typography>
+          </Box>
+        </Fade>
+      </Modal>
+    </div>
+  );
+}

--- a/front/src/providers/index.tsx
+++ b/front/src/providers/index.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { RecoilRoot } from "recoil";
+
+export default function AppProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <RecoilRoot>{children}</RecoilRoot>;
+}

--- a/front/src/recoilState/index.ts
+++ b/front/src/recoilState/index.ts
@@ -1,0 +1,3 @@
+import { modalOpenState, modalTitleState } from "./modalState";
+
+export { modalOpenState, modalTitleState };

--- a/front/src/recoilState/modalState.ts
+++ b/front/src/recoilState/modalState.ts
@@ -1,0 +1,12 @@
+"use client";
+import { atom } from "recoil";
+
+export const modalOpenState = atom({
+  key: "modalOpenState",
+  default: false,
+});
+
+export const modalTitleState = atom({
+  key: "modalTitleState",
+  default: "",
+});


### PR DESCRIPTION
# 概要
新規登録のページを作成。
また、登録しないと使えない機能を使おうとしたときにユーザー登録を促すモーダルを作成。

## 実装項目
- [x] ホーム画面の上にモーダルが表示されること~
⇨ホームに限らず、登録を促すモーダル表示のコンポーネントを作成
- [x] 名前の入力項目があること
- [x] メールアドレスの入力項目があること
- [x] パスワードの入力項目があること
- [x] パスワード確認の入力項目があること
- [x] 新規登録ボタンがあること
- [x] ログインページへの誘導リンクがあること
- [x] 新規登録ページへ遷移すること
⇨モーダルから遷移可能
- [x] ログインページへの誘導リンクがあること
⇨モーダルから遷移可能

## 追加実装
- [x] レスポンシブ対応
- [x] 国際化
- [x] バリデーション
   - [x] 名前が無記入だったとき
   - [x] メールアドレスが無記入だったとき
   - [x] メールアドレスがメールアドレスの形式に沿っていないとき
   - [x] パスワードが無記入だったとき
   - [x] パスワードが6文字未満だったとき
   - [x] パスワード確認が無記入だったとき
   - [x] パスワード確認が6文字未満だったとき
   - [x] パスワード確認がパスワードと一致していないとき
- [x] バリデーションに引っかかったとき、バリデーション内容が各項目の下に表示される
- [x] 「作品を投稿」は登録必須なのでモーダルを表示させるようにした

## 実装状況
| 新規登録フォーム | バリデーション表示 |
| ---- | ---- |
| <img src="https://i.gyazo.com/3ba445a20ba1d3d389224534785d6e19.png" width="400px" /> | <img src="https://i.gyazo.com/a4bb2cf55e8c1abcc85033177ae7c9b6.png" width="300px" /> |

| モーダル |
| ---- |
| <img src="https://i.gyazo.com/ce6b87b9ee8015d5a060807356f025a7.gif" width="400px" /> |