### PR TITLE
【refactor】国際化の見出しの命名変更

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -50,7 +50,7 @@
   "General": {
     "send": "送信",
     "backHome": "ホームへ戻る",
-    "followedNewIllusts": "フォロー新着順",
-    "newIllusts": "新着順"
+    "followedNewPosts": "フォロー新着順",
+    "newPosts": "新着順"
   }
 }

--- a/front/src/app/[locale]/page.tsx
+++ b/front/src/app/[locale]/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
     <div className="w-full flex flex-col gap-16">
       <article>
         <h2 className="text-2xl text-start mb-4 ml-8 font-semibold">
-          {t_General("followedNewIllusts")}
+          {t_General("followedNewPosts")}
         </h2>
         <section>
           <UI.IllustCarousel illustsData={illusts} />
@@ -27,7 +27,7 @@ export default function Home() {
       </article>
       <article>
         <h2 className="text-2xl text-start mb-4 ml-8 font-semibold">
-          {t_General("newIllusts")}
+          {t_General("newPosts")}
         </h2>
         <section>
           <UI.IllustCarousel illustsData={illusts} />


### PR DESCRIPTION
# 修正内容
「フォロー新着順」と「新着順」の見出し名は、本リリースで小説投稿もあることからイラストに絞らないようにするため、`Illusts`から`Posts`に修正しました。