### PR TITLE
【feature】詳細検索のモーダル作成 close #52

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -62,5 +62,15 @@
     "total": "合計",
     "posts": "作品",
     "detailsSearch": "詳細検索"
+  },
+  "SearchOption": {
+    "postTitle": "作品名",
+    "gameSystem": "システム名",
+    "synalio": "シナリオ名",
+    "tag": "タグ",
+    "userName": "ユーザー名",
+    "andSearch": "AND検索",
+    "orSearch": "OR検索",
+    "search": "検索"
   }
 }

--- a/front/src/app/[locale]/illusts/components/index.ts
+++ b/front/src/app/[locale]/illusts/components/index.ts
@@ -1,3 +1,4 @@
 import ToggleSort from "./toggleSort";
+import SearchModal from "./searchModal";
 
-export { ToggleSort };
+export { ToggleSort, SearchModal };

--- a/front/src/app/[locale]/illusts/components/searchModal.tsx
+++ b/front/src/app/[locale]/illusts/components/searchModal.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as UI from "@/components/ui";
+import * as MUI from "@mui/material";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+import { useRouter } from "@/lib";
+
+// 仮データをハードコーディング
+const Tags = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  title: `タグ${i}`,
+}));
+
+const GameSystems = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  name: `システム${i}`,
+}));
+
+const Synalios = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  title: `シナリオ${i}`,
+}));
+
+enum SearchType {
+  AND = 0,
+  OR = 1,
+}
+
+const style = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  bgcolor: "background.paper",
+  width: "100%",
+  maxWidth: "600px",
+  boxShadow: 24,
+  p: 4,
+  borderRadius: 1,
+  display: "flex",
+  flexDirection: "column",
+};
+
+export default function SearchModal() {
+  const [open, setOpen] = useState(false);
+  const t_Search = useTranslations("Search");
+  const [postTitle, setPostTitle] = useState("");
+  const [gameSystem, setGameSystem] = useState(0);
+  const [synalioName, setSynalioName] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [userName, setUserName] = useState("");
+  const [searchType, setSearchType] = useState(SearchType.AND);
+  const router = useRouter();
+
+  const handleSearchButton = () => {
+    setOpen(true);
+  };
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!postTitle && !gameSystem && !synalioName && !tags.length && !userName)
+      return;
+
+    let query = "?";
+    // 作品名取得
+    if (postTitle) query += `postTitle=${postTitle}`;
+
+    // システムの番号取得
+    // TODO : システム名にするか悩む
+    if (gameSystem)
+      query += getQuery(query, "gameSystem", gameSystem.toString());
+
+    // シナリオ名取得
+    if (synalioName) query += getQuery(query, "synalioName", synalioName);
+
+    // タグ取得
+    // TODO : 空白削除の処理は未実装
+    if (tags.length >= 1) query += getQuery(query, "tags", tags.join(","));
+
+    // ユーザー名取得
+    if (userName) query += getQuery(query, "userName", userName);
+
+    // 検索タイプ取得
+    query += getQuery(query, "searchType", searchType);
+
+    setOpen(false);
+
+    router.push(`/illusts${query}`);
+  };
+
+  const getQuery = (query: string, key: string, value: string | number) => {
+    return query === "?" ? `${key}=${value}` : `&${key}=${value}`;
+  };
+
+  return (
+    <>
+      <MUI.Button
+        variant="contained"
+        className="bg-orange-200 hover:bg-orange-400 text-black"
+        onClick={handleSearchButton}
+      >
+        {t_Search("detailsSearch")}
+      </MUI.Button>
+      <MUI.Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={open}
+        onClose={() => setOpen(false)}
+        closeAfterTransition
+        slots={{ backdrop: MUI.Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 300,
+          },
+        }}
+      >
+        <MUI.Fade in={open}>
+          <MUI.Box sx={style} className="md:top-[45%]">
+            <MUI.IconButton
+              aria-label="close"
+              onClick={() => setOpen(false)}
+              className="absolute right-0 top-0"
+            >
+              <HighlightOffIcon />
+            </MUI.IconButton>
+            <UI.H2>詳細検索</UI.H2>
+
+            <form className="flex flex-col gap-4" onSubmit={handleSearch}>
+              <MUI.TextField
+                label="作品名"
+                variant="outlined"
+                onChange={(e) => setPostTitle(e.target.value)}
+                fullWidth
+              />
+
+              <MUI.Select
+                label="システム名"
+                onChange={(e) => setGameSystem(e.target.value as number)}
+                defaultValue={0}
+                fullWidth
+              >
+                {GameSystems.map((system) => (
+                  <MUI.MenuItem key={system.id} value={system.id}>
+                    {system.name}
+                  </MUI.MenuItem>
+                ))}
+              </MUI.Select>
+
+              <MUI.Autocomplete
+                options={Synalios.map((synalio) => synalio.title)}
+                getOptionLabel={(option) => option}
+                renderInput={(params) => (
+                  <MUI.TextField
+                    {...params}
+                    label="シナリオ名"
+                    placeholder="シナリオ名"
+                  />
+                )}
+                fullWidth
+                onInputChange={(e, value) => setSynalioName(value)}
+                freeSolo
+                value={synalioName}
+                onChange={(_, value) => setSynalioName(value || "")}
+              />
+
+              <MUI.Autocomplete
+                multiple
+                options={Tags.map((tag) => tag.title)}
+                getOptionLabel={(option) => option}
+                renderInput={(params) => (
+                  <MUI.TextField {...params} label="タグ" placeholder="タグ" />
+                )}
+                fullWidth
+                onChange={(_, value) => setTags(value)}
+                freeSolo
+                value={tags}
+              />
+
+              <MUI.TextField
+                label="ユーザー名"
+                variant="outlined"
+                onChange={(e) => setUserName(e.target.value)}
+                fullWidth
+              />
+
+              <MUI.RadioGroup
+                row
+                defaultValue={SearchType.AND}
+                onChange={(e) => setSearchType(parseInt(e.target.value))}
+                value={searchType}
+                className="flex justify-center items-center gap-3"
+              >
+                <MUI.FormControlLabel
+                  value={SearchType.AND}
+                  control={<MUI.Radio />}
+                  label="AND検索"
+                />
+                <MUI.FormControlLabel
+                  value={SearchType.OR}
+                  control={<MUI.Radio />}
+                  label="OR検索"
+                />
+              </MUI.RadioGroup>
+              <div className="m-auto">
+                <MUI.Button
+                  variant="contained"
+                  className="bg-orange-200 hover:bg-orange-400 text-black"
+                  type="submit"
+                >
+                  検索
+                </MUI.Button>
+              </div>
+            </form>
+          </MUI.Box>
+        </MUI.Fade>
+      </MUI.Modal>
+    </>
+  );
+}

--- a/front/src/app/[locale]/illusts/components/searchModal.tsx
+++ b/front/src/app/[locale]/illusts/components/searchModal.tsx
@@ -44,8 +44,9 @@ const style = {
 };
 
 export default function SearchModal() {
-  const [open, setOpen] = useState(false);
   const t_Search = useTranslations("Search");
+  const t_SearchOption = useTranslations("SearchOption");
+  const [open, setOpen] = useState(false);
   const [postTitle, setPostTitle] = useState("");
   const [gameSystem, setGameSystem] = useState(0);
   const [synalioName, setSynalioName] = useState("");
@@ -125,18 +126,18 @@ export default function SearchModal() {
             >
               <HighlightOffIcon />
             </MUI.IconButton>
-            <UI.H2>詳細検索</UI.H2>
+            <UI.H2>{t_Search("detailsSearch")}</UI.H2>
 
             <form className="flex flex-col gap-4" onSubmit={handleSearch}>
               <MUI.TextField
-                label="作品名"
+                label={t_SearchOption("postTitle")}
                 variant="outlined"
                 onChange={(e) => setPostTitle(e.target.value)}
                 fullWidth
               />
 
               <MUI.Select
-                label="システム名"
+                label={t_SearchOption("gameSystem")}
                 onChange={(e) => setGameSystem(e.target.value as number)}
                 defaultValue={0}
                 fullWidth
@@ -154,8 +155,8 @@ export default function SearchModal() {
                 renderInput={(params) => (
                   <MUI.TextField
                     {...params}
-                    label="シナリオ名"
-                    placeholder="シナリオ名"
+                    label={t_SearchOption("synalio")}
+                    placeholder={t_SearchOption("synalio")}
                   />
                 )}
                 fullWidth
@@ -170,7 +171,11 @@ export default function SearchModal() {
                 options={Tags.map((tag) => tag.title)}
                 getOptionLabel={(option) => option}
                 renderInput={(params) => (
-                  <MUI.TextField {...params} label="タグ" placeholder="タグ" />
+                  <MUI.TextField
+                    {...params}
+                    label={t_SearchOption("tag")}
+                    placeholder={t_SearchOption("tag")}
+                  />
                 )}
                 fullWidth
                 onChange={(_, value) => setTags(value)}
@@ -179,7 +184,7 @@ export default function SearchModal() {
               />
 
               <MUI.TextField
-                label="ユーザー名"
+                label={t_SearchOption("userName")}
                 variant="outlined"
                 onChange={(e) => setUserName(e.target.value)}
                 fullWidth
@@ -195,12 +200,12 @@ export default function SearchModal() {
                 <MUI.FormControlLabel
                   value={SearchType.AND}
                   control={<MUI.Radio />}
-                  label="AND検索"
+                  label={t_SearchOption("andSearch")}
                 />
                 <MUI.FormControlLabel
                   value={SearchType.OR}
                   control={<MUI.Radio />}
-                  label="OR検索"
+                  label={t_SearchOption("orSearch")}
                 />
               </MUI.RadioGroup>
               <div className="m-auto">
@@ -209,7 +214,7 @@ export default function SearchModal() {
                   className="bg-orange-200 hover:bg-orange-400 text-black"
                   type="submit"
                 >
-                  検索
+                  {t_SearchOption("search")}
                 </MUI.Button>
               </div>
             </form>

--- a/front/src/app/[locale]/illusts/page.tsx
+++ b/front/src/app/[locale]/illusts/page.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/lib";
 import { IndexIllustData } from "@/types";
 import * as MUI from "@mui/material";
 import { useTranslations } from "next-intl";
-import { ToggleSort } from "./components";
+import { SearchModal, ToggleSort } from "./components";
 
 // 仮データをハードコーディング
 const illusts = Array.from({ length: 20 }).map((_, i) => ({
@@ -16,6 +16,12 @@ const illusts = Array.from({ length: 20 }).map((_, i) => ({
     avatar: "/assets/900x1600.png",
   },
   count: Math.floor(Math.random() * 2) + 1,
+}));
+
+// 仮データをハードコーディング
+const Tags = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  title: `タグ${i}`,
 }));
 
 export default function IllustsPage({
@@ -56,12 +62,7 @@ export default function IllustsPage({
               {t_Search("posts")}
             </h4>
             <div>
-              <MUI.Button
-                variant="contained"
-                className="bg-orange-200 hover:bg-orange-400 text-black"
-              >
-                {t_Search("detailsSearch")}
-              </MUI.Button>
+              <SearchModal />
             </div>
           </div>
         </section>

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -49,6 +49,7 @@ export default function Headers() {
               height={300}
               style={{ width: "150px", height: "auto" }}
               alt="logo"
+              priority={true}
             />
           </Link>
         </h1>


### PR DESCRIPTION
# 概要
詳細検索のモーダルを作成しました。
検索後はURLパラメーターに含め遷移します。

## 実装項目
- [x] 検索オプションボタンや詳細検索ボタンを押すとモーダルが表示されること
⇨検索オプションボタンは排除しています #83
- [x] 下記フォームがあること
   - [x] 作品名（テキスト）
   - [x] システム（選択）
   - [x] シナリオ（テキスト・オートコンプリート）
   - [x] タグ（テキスト、オートコンプリート）
   - [x] ユーザー名（テキスト）
   - [x] OR検索かAND検索か（ラジオ）
- [x] 検索ボタンがあること
- [x] 検索ボタンを押すと検索結果ページへ遷移すること
- [x] 閉じるボタンがあること
- [x] 閉じるボタンを押すとモーダルが閉じること

## 追加の実装
シナリオ名とタグはオートコンプリートも出来ますが、検索結果が０件だったときに０件と表示できるようにフリー検索もできるようにしています。

## 実装状況
| PC | SP |
| ---- | ---- |
| <img src="https://i.gyazo.com/1c63daa2bd1b3ef0d408d4b551ee5ee6.gif" width="500px" /> | <img src="https://i.gyazo.com/67ff3f72ca793c3c2d2bc477e0ef9e42.gif" width="200px" /> |