### PR TITLE
【feature】アカウント設定画面作成 close #40

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -80,5 +80,20 @@
     "unFollow": "フォロー解除",
     "send": "送信",
     "requiredComment": "コメント機能はログインで使えます"
+  },
+  "AccountSettings": {
+    "settings": "設定",
+    "accountName": "アカウント名",
+    "email": "メールアドレス",
+    "changeEmail":"変更する",
+    "password": "パスワード",
+    "changePassword": "パスワード変更",
+    "notificationSettings": "通知設定",
+    "app": "アプリ",
+    "mail": "メール",
+    "favorite": "いいねされたとき",
+    "bookmark": "ブックマークされたとき",
+    "comment": "コメントされたとき",
+    "follow": "フォローされたとき"
   }
 }

--- a/front/src/app/[locale]/account/[id]/page.tsx
+++ b/front/src/app/[locale]/account/[id]/page.tsx
@@ -4,7 +4,7 @@ import * as MUI from "@mui/material";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
-const noticeStates = {
+const noticeStatesDummy = {
   app: {
     favorite: true,
     bookmark: true,
@@ -63,7 +63,7 @@ export default function AccountPage() {
           <h3 className="text-xl font-semibold text-center mt-10 mb-2">
             {t_AccountSettings("notificationSettings")}
           </h3>
-          <Tabs noticeStates={noticeStates} />
+          <Tabs noticeStates={noticeStatesDummy} />
         </section>
       </div>
     </article>
@@ -127,10 +127,9 @@ function Tabs({ noticeStates }: { noticeStates: NoticeStates }) {
 }
 
 function CustomTabPanel(props: TabPanelProps) {
-  const { value, index, ...other } = props;
-  const [noticeState, setNoticeState] = useState<NoticeState>(
-    props.noticeState
-  );
+  const { value, noticeState, index, ...other } = props;
+  const [newNoticeState, setNewNoticeState] =
+    useState<NoticeState>(noticeState);
   const t_AccountSettings = useTranslations("AccountSettings");
 
   return (
@@ -147,7 +146,7 @@ function CustomTabPanel(props: TabPanelProps) {
             control={
               <MUI.Switch
                 onChange={() =>
-                  setNoticeState((prevState) => ({
+                  setNewNoticeState((prevState) => ({
                     ...prevState,
                     favorite: !prevState.favorite,
                   }))
@@ -155,13 +154,13 @@ function CustomTabPanel(props: TabPanelProps) {
               />
             }
             label={t_AccountSettings("favorite")}
-            checked={noticeState.favorite}
+            checked={newNoticeState.favorite}
           />
           <MUI.FormControlLabel
             control={
               <MUI.Switch
                 onChange={() =>
-                  setNoticeState((prevState) => ({
+                  setNewNoticeState((prevState) => ({
                     ...prevState,
                     bookmark: !prevState.bookmark,
                   }))
@@ -169,13 +168,13 @@ function CustomTabPanel(props: TabPanelProps) {
               />
             }
             label={t_AccountSettings("bookmark")}
-            checked={noticeState.bookmark}
+            checked={newNoticeState.bookmark}
           />
           <MUI.FormControlLabel
             control={
               <MUI.Switch
                 onChange={() =>
-                  setNoticeState((prevState) => ({
+                  setNewNoticeState((prevState) => ({
                     ...prevState,
                     comment: !prevState.comment,
                   }))
@@ -183,13 +182,13 @@ function CustomTabPanel(props: TabPanelProps) {
               />
             }
             label={t_AccountSettings("comment")}
-            checked={noticeState.comment}
+            checked={newNoticeState.comment}
           />
           <MUI.FormControlLabel
             control={
               <MUI.Switch
                 onChange={() =>
-                  setNoticeState((prevState) => ({
+                  setNewNoticeState((prevState) => ({
                     ...prevState,
                     follow: !prevState.follow,
                   }))
@@ -197,7 +196,7 @@ function CustomTabPanel(props: TabPanelProps) {
               />
             }
             label={t_AccountSettings("follow")}
-            checked={noticeState.follow}
+            checked={newNoticeState.follow}
           />
         </>
       )}

--- a/front/src/app/[locale]/account/[id]/page.tsx
+++ b/front/src/app/[locale]/account/[id]/page.tsx
@@ -1,3 +1,196 @@
+"use client";
+
+import * as MUI from "@mui/material";
+import { useState } from "react";
+
+const noticeStates = {
+  app: {
+    favorite: true,
+    bookmark: true,
+    comment: true,
+    follow: true,
+  },
+  email: {
+    favorite: false,
+    bookmark: false,
+    comment: false,
+    follow: false,
+  },
+};
+
 export default function AccountPage() {
-  return <div>アカウントページ</div>;
+  return (
+    <article className="my-8 m-auto w-full px-4">
+      <div className="bg-white p-8 rounded max-w-[480px] w-full m-auto flex flex-col justify-center items-center">
+        <h2 className="text-2xl font-semibold text-center mb-4">設定</h2>
+        <section className="max-w-96 w-full">
+          <dl className="md:grid md:grid-cols-2 md:gap-y-2 m-auto">
+            <dt className="md:border-b md:border-slate-300 md:pb-2">
+              アカウント名
+            </dt>
+            <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2">
+              アカウント名
+            </dd>
+            <dt className="md:border-b md:border-slate-300 md:pb-2">
+              メールアドレス
+            </dt>
+            <dd className="flex flex-col ml-4 md:ml-0 border-b border-slate-300 pb-2">
+              *****@example.com
+              <div>
+                <MUI.Button
+                  variant="contained"
+                  size="small"
+                  className="text-xs inline-block"
+                >
+                  変更する
+                </MUI.Button>
+              </div>
+            </dd>
+            <dt className="md:border-b md:border-slate-300 md:pb-2">
+              パスワード
+            </dt>
+            <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2">
+              <button className="text-sm text-blue-500 underline hover:opacity-50 transition-all">
+                パスワードを変更する
+              </button>
+            </dd>
+          </dl>
+
+          <h3 className="text-xl font-semibold text-center mt-10 mb-2">
+            通知設定
+          </h3>
+          <Tabs noticeStates={noticeStates} />
+        </section>
+      </div>
+    </article>
+  );
+}
+
+interface NoticeState {
+  favorite: boolean;
+  bookmark: boolean;
+  comment: boolean;
+  follow: boolean;
+}
+
+interface NoticeStates {
+  app: NoticeState;
+  email: NoticeState;
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+  noticeState: NoticeState;
+}
+
+function Tabs({ noticeStates }: { noticeStates: NoticeStates }) {
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const a11yProps = (index: number) => {
+    return {
+      id: `simple-tab-${index}`,
+      "aria-controls": `simple-tabpanel-${index}`,
+    };
+  };
+
+  return (
+    <MUI.Box sx={{ width: "100%" }}>
+      <MUI.Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <MUI.Tabs value={value} onChange={handleChange} aria-label="通知設定">
+          <MUI.Tab label="アプリ" {...a11yProps(0)} />
+          <MUI.Tab label="メール" {...a11yProps(1)} />
+        </MUI.Tabs>
+      </MUI.Box>
+      <CustomTabPanel value={value} index={0} noticeState={noticeStates.app} />
+      <CustomTabPanel
+        value={value}
+        index={1}
+        noticeState={noticeStates.email}
+      />
+    </MUI.Box>
+  );
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { value, index, ...other } = props;
+  const [noticeState, setNoticeState] = useState<NoticeState>(
+    props.noticeState
+  );
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <>
+          <MUI.FormControlLabel
+            control={
+              <MUI.Switch
+                onChange={() =>
+                  setNoticeState((prevState) => ({
+                    ...prevState,
+                    favorite: !prevState.favorite,
+                  }))
+                }
+              />
+            }
+            label="いいねされたとき"
+            checked={noticeState.favorite}
+          />
+          <MUI.FormControlLabel
+            control={
+              <MUI.Switch
+                onChange={() =>
+                  setNoticeState((prevState) => ({
+                    ...prevState,
+                    bookmark: !prevState.bookmark,
+                  }))
+                }
+              />
+            }
+            label="ブックマークされたとき"
+            checked={noticeState.bookmark}
+          />
+          <MUI.FormControlLabel
+            control={
+              <MUI.Switch
+                onChange={() =>
+                  setNoticeState((prevState) => ({
+                    ...prevState,
+                    comment: !prevState.comment,
+                  }))
+                }
+              />
+            }
+            label="コメントされたとき"
+            checked={noticeState.comment}
+          />
+          <MUI.FormControlLabel
+            control={
+              <MUI.Switch
+                onChange={() =>
+                  setNoticeState((prevState) => ({
+                    ...prevState,
+                    follow: !prevState.follow,
+                  }))
+                }
+              />
+            }
+            label="フォローされたとき"
+            checked={noticeState.follow}
+          />
+        </>
+      )}
+    </div>
+  );
 }

--- a/front/src/app/[locale]/account/[id]/page.tsx
+++ b/front/src/app/[locale]/account/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as MUI from "@mui/material";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 const noticeStates = {
@@ -19,20 +20,23 @@ const noticeStates = {
 };
 
 export default function AccountPage() {
+  const t_AccountSettings = useTranslations("AccountSettings");
   return (
     <article className="my-8 m-auto w-full px-4">
       <div className="bg-white p-8 rounded max-w-[480px] w-full m-auto flex flex-col justify-center items-center">
-        <h2 className="text-2xl font-semibold text-center mb-4">設定</h2>
+        <h2 className="text-2xl font-semibold text-center mb-4">
+          {t_AccountSettings("settings")}
+        </h2>
         <section className="max-w-96 w-full">
           <dl className="md:grid md:grid-cols-2 md:gap-y-2 m-auto">
             <dt className="md:border-b md:border-slate-300 md:pb-2">
-              アカウント名
+              {t_AccountSettings("accountName")}
             </dt>
             <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2">
               アカウント名
             </dd>
             <dt className="md:border-b md:border-slate-300 md:pb-2">
-              メールアドレス
+              {t_AccountSettings("email")}
             </dt>
             <dd className="flex flex-col ml-4 md:ml-0 border-b border-slate-300 pb-2">
               *****@example.com
@@ -42,22 +46,22 @@ export default function AccountPage() {
                   size="small"
                   className="text-xs inline-block"
                 >
-                  変更する
+                  {t_AccountSettings("changeEmail")}
                 </MUI.Button>
               </div>
             </dd>
             <dt className="md:border-b md:border-slate-300 md:pb-2">
-              パスワード
+              {t_AccountSettings("password")}
             </dt>
             <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2">
               <button className="text-sm text-blue-500 underline hover:opacity-50 transition-all">
-                パスワードを変更する
+                {t_AccountSettings("changePassword")}
               </button>
             </dd>
           </dl>
 
           <h3 className="text-xl font-semibold text-center mt-10 mb-2">
-            通知設定
+            {t_AccountSettings("notificationSettings")}
           </h3>
           <Tabs noticeStates={noticeStates} />
         </section>
@@ -87,6 +91,7 @@ interface TabPanelProps {
 
 function Tabs({ noticeStates }: { noticeStates: NoticeStates }) {
   const [value, setValue] = useState(0);
+  const t_AccountSettings = useTranslations("AccountSettings");
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
@@ -102,9 +107,13 @@ function Tabs({ noticeStates }: { noticeStates: NoticeStates }) {
   return (
     <MUI.Box sx={{ width: "100%" }}>
       <MUI.Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-        <MUI.Tabs value={value} onChange={handleChange} aria-label="通知設定">
-          <MUI.Tab label="アプリ" {...a11yProps(0)} />
-          <MUI.Tab label="メール" {...a11yProps(1)} />
+        <MUI.Tabs
+          value={value}
+          onChange={handleChange}
+          aria-label={t_AccountSettings("notificationSettings")}
+        >
+          <MUI.Tab label={t_AccountSettings("app")} {...a11yProps(0)} />
+          <MUI.Tab label={t_AccountSettings("mail")} {...a11yProps(1)} />
         </MUI.Tabs>
       </MUI.Box>
       <CustomTabPanel value={value} index={0} noticeState={noticeStates.app} />
@@ -122,6 +131,7 @@ function CustomTabPanel(props: TabPanelProps) {
   const [noticeState, setNoticeState] = useState<NoticeState>(
     props.noticeState
   );
+  const t_AccountSettings = useTranslations("AccountSettings");
 
   return (
     <div
@@ -144,7 +154,7 @@ function CustomTabPanel(props: TabPanelProps) {
                 }
               />
             }
-            label="いいねされたとき"
+            label={t_AccountSettings("favorite")}
             checked={noticeState.favorite}
           />
           <MUI.FormControlLabel
@@ -158,7 +168,7 @@ function CustomTabPanel(props: TabPanelProps) {
                 }
               />
             }
-            label="ブックマークされたとき"
+            label={t_AccountSettings("bookmark")}
             checked={noticeState.bookmark}
           />
           <MUI.FormControlLabel
@@ -172,7 +182,7 @@ function CustomTabPanel(props: TabPanelProps) {
                 }
               />
             }
-            label="コメントされたとき"
+            label={t_AccountSettings("comment")}
             checked={noticeState.comment}
           />
           <MUI.FormControlLabel
@@ -186,7 +196,7 @@ function CustomTabPanel(props: TabPanelProps) {
                 }
               />
             }
-            label="フォローされたとき"
+            label={t_AccountSettings("follow")}
             checked={noticeState.follow}
           />
         </>


### PR DESCRIPTION
# 概要
アカウント設定の画面を作成しました。
通知設定もここで行っています。

## 実装項目
- [x] 基本設定が表示されている
   - [x] アカウント名が表示されている
   - [x] メールアドレスが表示されている
   - [x] メールアドレスを変更するリンクが表示されている
   - [x] パスワードを変更するリンクが表示されている
- [x] 通知設定が表示されている
   - [x] アプリ内通知一覧が表示されている
      - [x] いいねされたときのトグルが表示されている
      - [x] ブックマークされたときのトグルが表示されている
      - [x] コメントされたときのトグルが表示されている
      - [x] フォローされたときのトグルが表示されている
   - [x] メール通知一覧が表示されている
      - [x] いいねされたときのトグルが表示されている
      - [x] ブックマークされたときのトグルが表示されている
      - [x] コメントされたときのトグルが表示されている
      - [x] フォローされたときのトグルが表示されている

## 実装状況
| PC | SP |
| ---- | ---- |
| <img src="https://i.gyazo.com/b195dbcb3349bf18ab0f2aa5b53ea56e.png" width="535px" /> | <img src="https://i.gyazo.com/5c1a3d2dd0a06a3ba45d6d4ff2d9eb1b.png" width="265px" /> |