### PR TITLE
【feature】ユーザーと認証のモデル・テーブル作成 close #11

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem "pry-byebug"
+  gem 'annotate' # モデルのスキーマを表示する
 end
 
 group :development do

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
@@ -272,6 +275,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   debug
   devise

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
   def index
     render json: { message: "Hello, world!" }
   end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
   def index
     render json: { message: "Hello, world!" }
   end

--- a/back/app/models/authentiction.rb
+++ b/back/app/models/authentiction.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: authentictions
+#
+#  id         :bigint           not null, primary key
+#  provider   :string           not null
+#  uid        :string           default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+class Authentiction < ActiveRecord::Base
+  belongs_to :user
+  validations :provider, :uid, presence: true
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: users
+#
+#  id                 :bigint           not null, primary key
+#  provider           :string           not null
+#  uid                :string           default(""), not null
+#  encrypted_password :string           default(""), not null
+#  name               :string
+#  email              :string
+#  tokens             :json
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+class User < ActiveRecord::Base
+  extend Devise::Models
+  devise :database_authenticatable, :registerable,
+        :recoverable, :rememberable, :validatable,
+        :omniauthable, omniauth_providers: %i[google_oauth2 discord]
+  include DeviseTokenAuth::Concerns::User
+  has_many :authentications, dependent: :destroy
+end

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/back/config/initializers/omniauth.rb
+++ b/back/config/initializers/omniauth.rb
@@ -1,0 +1,6 @@
+# config/initializers/omniauth.rb
+Rails.application.config.middleware.use OmniAuth::Builder do
+  OmniAuth.config.allowed_request_methods = [:get]
+  provider :google_oauth2, ENV['GOOGLE_KEY'],   ENV['GOOGLE_SECRET'], scope: 'email,profile'
+  provider :discord,        ENV['DISCORD_KEY'],  ENV['DISCORD_SECRET'], scope: 'email,identify'
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   root 'application#index'
 end

--- a/back/db/migrate/20240428023924_devise_token_auth_create_users.rb
+++ b/back/db/migrate/20240428023924_devise_token_auth_create_users.rb
@@ -1,0 +1,46 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
+      # t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      # t.datetime :remember_created_at
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :email
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    # add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/back/db/migrate/20240428025756_create_authentictions.rb
+++ b/back/db/migrate/20240428025756_create_authentictions.rb
@@ -1,0 +1,12 @@
+class CreateAuthentictions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authentictions do |t|
+      t.string :provider, null: false
+      t.string :uid, null: false, default: ""
+
+      t.timestamps
+    end
+    add_reference :authentictions, :user, foreign_key: true
+    add_index :authentictions, [:uid, :provider], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,0 +1,41 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_04_28_025756) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "authentictions", force: :cascade do |t|
+    t.string "provider", null: false
+    t.string "uid", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["uid", "provider"], name: "index_authentictions_on_uid_and_provider", unique: true
+    t.index ["user_id"], name: "index_authentictions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "name"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+  add_foreign_key "authentictions", "users"
+end


### PR DESCRIPTION
# 概要
ユーザーと認証のモデル・テーブル作成をしました。
モデルのバリデーションは未実装です

# 実装項目
- [x] [devise](https://github.com/heartcombo/devise)をもとにモデルを作成
   ⇨devise_token_authをもとに作成しました。
- [x] マイグレーション
   ⇨ビルド通ってます。

# 実装状況
![image](https://github.com/topi0247/Project-AStoryer/assets/23026318/c78dcd61-8aad-4e17-ae9f-f96c8b0598c1)

## 補足
モデルにスキーマ情報を表示させるため、Gemのanotateを導入しました。