### PR TITLE
【feature】新規登録とログイン機能実装 close #12

### DIFF
--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCallbacksController
+  # オーバーライド
+  def redirect_callbacks
+    auth = Authentiction.find_for_oauth(request.env['omniauth.auth'])
+
+    # トークンを生成
+    client_id = SecureRandom.urlsafe_base64(nil, false)
+    token     = SecureRandom.urlsafe_base64(nil, false)
+    token_hash = BCrypt::Password.create(token)
+    expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+
+    # ユーザーがいたらログイン
+    if auth.present?
+      user = auth.user
+      sign_in(user)
+      save_to_redirect(user, token_hash, client_id, token, expiry)
+    else
+      # ユーザーがいなかったら同じメールアドレスのユーザーが居るか確認
+      user = User.from_omniauth(request.env['omniauth.auth'])
+
+      if user.persisted?
+        sign_in(user)
+        # ユーザーがいたら、認証情報を追加
+        user.authentications.create(provider: request.env['omniauth.auth'].provider, uid: request.env['omniauth.auth'].uid)
+        save_to_redirect(user, token_hash, client_id, token, expiry)
+      else
+        redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+      end
+    end
+  end
+
+  private
+
+  # 保存とリダイレクト
+  def save_to_redirect(user, token_hash, client_id, token, expiry)
+    user.tokens[client_id] = {
+      token: token_hash,
+      expiry: expiry
+    }
+
+    if user.save
+      redirect_to "#{ENV['FRONT_URL']}/ja/tasks?uid=#{user.uid}&token=#{token}&client=#{client_id}&expiry=#{expiry}", allow_other_host: true
+    else
+      redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+    end
+  end
+end

--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -45,10 +45,4 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
       end
     end
   end
-
-  private
-
-  # def sign_up_params
-  #   params.permit(:name, :email, :password, :password_confirmation)
-  # end
 end

--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,54 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  wrap_parameters false
+
+  def create
+    super do |resource|
+      if resource.persisted?
+        if resource.active_for_authentication?
+          # 自動ログイン
+          sign_in(resource)
+
+          # トークンを生成
+          client_id = SecureRandom.urlsafe_base64(nil, false)
+          token     = SecureRandom.urlsafe_base64(nil, false)
+          token_hash = BCrypt::Password.create(token)
+          expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+
+          resource.tokens[client_id] = {
+            token:  token_hash,
+            expiry: expiry
+          }
+
+          resource.save!
+
+          response.headers['uid'] = resource.uid
+          response.headers['client'] = client_id
+          response.headers['expiry'] = expiry
+          response.headers['access-token'] = token
+
+          # 認証トークンとユーザー情報を含むJSONを返す
+          render json: {
+            success: true,
+            data:   {
+              id: resource.id,
+              name: resource.name,
+            },
+            message: "登録が完了しました。", # カスタムメッセージ等
+          } and return
+        else
+          # アカウントがまだ有効でない場合の処理
+          render json: { success: false, message: "アカウントが有効ではありません。" } and return
+        end
+      else
+        # ユーザーの保存に失敗した場合
+        render json: { success: false, message: resource.errors.full_messages } and return
+      end
+    end
+  end
+
+  private
+
+  # def sign_up_params
+  #   params.permit(:name, :email, :password, :password_confirmation)
+  # end
+end

--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
+  wrap_parameters false
+
+  protected
+
+  # ログイン成功時の処理オーバーライド
+  def render_create_success
+    render json: {
+      success: true,
+      user: { name: @resource.name, id: @resource.id },
+    }
+  end
+
+  def resource_name
+    :user
+  end
+end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::API
-  def index
-    render json: { message: "Hello, world!" }
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 end

--- a/back/app/models/authentiction.rb
+++ b/back/app/models/authentiction.rb
@@ -12,4 +12,8 @@
 class Authentiction < ActiveRecord::Base
   belongs_to :user
   validations :provider, :uid, presence: true
+
+  def self.find_for_oauth(auth)
+    find_by(provider: auth.provider, uid: auth.uid)
+  end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -21,4 +21,12 @@ class User < ActiveRecord::Base
         :omniauthable, omniauth_providers: %i[google_oauth2 discord]
   include DeviseTokenAuth::Concerns::User
   has_many :authentications, dependent: :destroy
+
+  def self.from_omniauth(auth)
+    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
+      user.email = auth.info.email
+      user.name = auth.info.name
+      user.password = Devise.friendly_token[0, 20]
+    end
+  end
 end

--- a/back/config/initializers/wrap_parameters.rb
+++ b/back/config/initializers/wrap_parameters.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters format: []
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
   root 'application#index'
+  
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for 'User', at: 'auth',controllers: {
+        omniauth_callbacks: 'api/v1/auth/omniauth_callbacks',
+        sessions:           'api/v1/auth/sessions',
+        registraions:       'api/v1/auth/registrations'
+      }
+    end
+  end
 end


### PR DESCRIPTION
# 概要
名前・メールアドレス・パスワード・パスワード確認で新規登録とメールアドレスとパスワードでログインできるようになりました。

## 実装項目
- [x] 新規登録
   - [x] アクセスできること
   - [x] 「名前」「メールアドレス」「パスワード」「パスワード確認」でデータを送信できること
   - [x] 上記項目でDBに保存できること
   - [ ] DBに保存後に自動ログインできること
      ⇨この時点での確認が難しいため未確認
   - [x] 上記成功後に成功した結果が返ってくること
   - [x] 失敗後に失敗した結果が返ってくること
      ⇨翻訳は失敗している
- [x] ログイン
   - [x] アクセスできること
   - [x] 「メールアドレス」「パスワード」でデータを送信できること
   - [x] 上記項目でユーザーを検索できること
      ⇨コンソールから名前での検索確認済み
   - [x] ログインに成功したら成功した結果が返ってくること
   - [x] ログインに失敗したら失敗した結果が返ってくること

## 実装状況
| 新規登録成功 | 新規登録失敗|
| ---- | ---- |
| <img src="https://i.gyazo.com/81b547589b08c9bc78444b23c993295b.png"  width="470" /> | <img src="https://i.gyazo.com/de5f48d1dc28aa6c45abb966adae0d18.png"  width="330" /> |
| ログイン成功 | ログイン失敗|
| <img src="https://i.gyazo.com/2f9391298ea19546f9482b4f89d8a209.png"  width="350" /> | <img src="https://i.gyazo.com/79f3600efc7b989acfeea9e14c990f6a.png"  width="450" /> |

# 補足
Google認証とDiscord認証はPostmanからの確認が難しいため、連携時に確認します