### PR TITLE
【feature】フォロー・プロフィールテーブル作成、ロールカラム追加 close #101

### DIFF
--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id           :bigint           not null, primary key
+#  avatar       :string
+#  header_image :string
+#  text         :text
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint           not null
+#
+class Profile < ApplicationRecord
+  validates :text, length: { maximum: 250 }
+end

--- a/back/app/models/relationship.rb
+++ b/back/app/models/relationship.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  follower_id :bigint           not null
+#  followed_id :bigint           not null
+#
+class Relationship < ActiveRecord::Base
+  belongs_to :follower, class_name: 'User', inverse_of: :following_relationships
+  belongs_to :followed, class_name: 'User', inverse_of: :follower_relationships
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -13,6 +13,7 @@
 #  tokens             :json
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  role               :integer          default(0)
 #
 class User < ActiveRecord::Base
   extend Devise::Models
@@ -21,6 +22,17 @@ class User < ActiveRecord::Base
         :omniauthable, omniauth_providers: %i[google_oauth2 discord]
   include DeviseTokenAuth::Concerns::User
   has_many :authentications, dependent: :destroy
+  has_one :profile, dependent: :destroy
+
+  # フォローしている人とフォローされている人を取得するためのアソシエーション
+  has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
+  has_many :follower_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
+  # フォローしている人を呼び出す
+  has_many :following, through: :following_relationships, source: :followed
+  # フォロワーを呼びたす
+  has_many :followers, through: :follower_relationships, source: :follower
+
+  enum role: { general: 0, admin: 1 } # general: 一般ユーザー, admin: 管理者
 
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -10,10 +10,10 @@
 #  encrypted_password :string           default(""), not null
 #  name               :string
 #  email              :string
+#  role               :integer          default("general")
 #  tokens             :json
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  role               :integer          default(0)
 #
 class User < ActiveRecord::Base
   extend Devise::Models

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
 
   # フォローしている人とフォローされている人を取得するためのアソシエーション
   has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy, inverse_of: :follower
-  has_many :follower_relationshis, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy, inverse_of: :followed
+  has_many :follower_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy, inverse_of: :followed
   # フォローしている人を呼び出す
   has_many :following, through: :following_relationships, source: :followed
   # フォロワーを呼びたす

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -25,8 +25,8 @@ class User < ActiveRecord::Base
   has_one :profile, dependent: :destroy
 
   # フォローしている人とフォローされている人を取得するためのアソシエーション
-  has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
-  has_many :follower_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
+  has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy, inverse_of: :follower
+  has_many :follower_relationshis, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy, inverse_of: :followed
   # フォローしている人を呼び出す
   has_many :following, through: :following_relationships, source: :followed
   # フォロワーを呼びたす

--- a/back/db/migrate/20240428023924_devise_token_auth_create_users.rb
+++ b/back/db/migrate/20240428023924_devise_token_auth_create_users.rb
@@ -30,6 +30,7 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[7.1]
       ## User Info
       t.string :name
       t.string :email
+      t.integer :role, default: 0
 
       ## Tokens
       t.json :tokens

--- a/back/db/migrate/20240428064154_create_profiles.rb
+++ b/back/db/migrate/20240428064154_create_profiles.rb
@@ -1,0 +1,12 @@
+class CreateProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profiles do |t|
+      t.string :avatar
+      t.string :header_image
+      t.text :text
+
+      t.timestamps
+    end
+    add_reference :profiles, :user, null: false, foreign_key: true
+  end
+end

--- a/back/db/migrate/20240428064238_create_follows.rb
+++ b/back/db/migrate/20240428064238_create_follows.rb
@@ -1,0 +1,9 @@
+class CreateFollows < ActiveRecord::Migration[7.1]
+  def change
+    create_table :relationships do |t|
+      t.timestamps
+    end
+    add_reference :relationships, :follower, null: false, foreign_key: { to_table: :users }
+    add_reference :relationships, :followed, null: false, foreign_key: { to_table: :users }
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_28_025756) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_28_064238) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,12 +24,32 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_28_025756) do
     t.index ["user_id"], name: "index_authentictions_on_user_id"
   end
 
+  create_table "profiles", force: :cascade do |t|
+    t.string "avatar"
+    t.string "header_image"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "follower_id", null: false
+    t.bigint "followed_id", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false
     t.string "uid", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "name"
     t.string "email"
+    t.integer "role", default: 0
     t.json "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -38,4 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_28_025756) do
   end
 
   add_foreign_key "authentictions", "users"
+  add_foreign_key "profiles", "users"
+  add_foreign_key "relationships", "users", column: "followed_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
 end


### PR DESCRIPTION
# 概要
フォロイー・フォロワーのテーブル、プロフィールテーブルを作成しました。
ユーザーテーブルにロールカラムを追加しています。

# 実装項目
- [x] users
   - [x] role { general: 0, admin: 1 }
- [x] profiles
   - [x] 外部キーuser_id : users
   - [x] avatar
   - [x] header_image
   - [x] text（プロフィールテキスト）
   - [x] タイムスタンプ
- [x] follows ⇨ relationshipsテーブルに変更
   - [x] 外部キーfollower_id : users
   - [x] 外部キーfollowed_id : users

## ER
スキーマファイルをER図に起こしたものです。
<img src="https://i.gyazo.com/b3ee5cee28e14c666c9c0a6de7da1b2f.png" width="400px" />

## 補足
自己結合については下記を参考にしました
[BUZZ BASE（バズベース）](https://runteq-fes-vol4.vercel.app/apps/3)
`inverse_of`については下記を参考にしました
[Active Recordのアソシエーションにおける :inverse_of の役割](https://zenn.dev/pofkuma/articles/a587b7352f3a31)

## 確認していただきたいこと
フォロイー・フォロワーの中間テーブルは自己結合になると認識しています。
上記補足にあるものを参考にしておりますが、この実装で問題ないか、その他気になったところあればご指摘いただきたいです。
どうぞよろしくお願いいたします。