### PR TITLE
【feature】ユーザーページのガワ作成 close #29

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+worker

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -56,7 +56,8 @@
     "followedNewPosts": "フォロー新着順",
     "newPosts": "新着順",
     "oldPosts": "投稿順",
-    "sortBy": "表示順"
+    "sortBy": "表示順",
+    "edit": "編集"
   },
   "Search": {
     "searchResult": "検索結果",
@@ -97,5 +98,13 @@
     "bookmark": "ブックマークされたとき",
     "comment": "コメントされたとき",
     "follow": "フォローされたとき"
+  },
+  "UserPage": {
+    "post": "投稿一覧",
+    "bookmark": "ブックマーク一覧",
+    "fusetter": "ふせったー",
+    "other": "その他",
+    "headerImage": "ヘッダー画像",
+    "avatar": "ユーザーアイコン"
   }
 }

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -2,6 +2,10 @@ import createNextIntlPlugin from "next-intl/plugin"
 const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['placehold.jp'], // ダミー画像のURLを許可
+  }
+};
 
 export default withNextIntl(nextConfig);

--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^6.0.0-alpha.2",
+    "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.15",
     "axios": "^1.6.8",
     "next": "14.2.1",

--- a/front/src/app/[locale]/layout.tsx
+++ b/front/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import "@/app/globals.css";
+import "@/styles/globals.css";
 import { NextIntlClientProvider, useMessages } from "next-intl";
 import AppProvider from "@/providers/index";
 import { MainLayout } from "@/components/layouts";

--- a/front/src/app/[locale]/users/[id]/bookmarks/page.tsx
+++ b/front/src/app/[locale]/users/[id]/bookmarks/page.tsx
@@ -1,3 +1,0 @@
-export default function UserBookmarkPage() {
-  return <div>ユーザーブックマークページ</div>;
-}

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -1,3 +1,186 @@
+import Image from "next/image";
+import * as MUI from "@mui/material";
+import * as UI from "@/components/ui";
+import { IndexIllustData } from "@/types";
+import { Illust } from "@/components/illusts";
+
+// 仮データをハードコーディング
+const illusts = Array.from({ length: 20 }).map((_, i) => ({
+  id: i,
+  image: "/assets/900x1600.png",
+  title: `イラスト${i}`,
+  user: {
+    id: i,
+    name: `ユーザー${i}`,
+    avatar: "/assets/900x1600.png",
+  },
+  count: Math.floor(Math.random() * 2) + 1,
+}));
+
 export default function UserPage() {
-  return <div>ユーザーページ</div>;
+  const imgUrl = "https://placehold.jp/1600x900.png";
+
+  return (
+    <>
+      <article className="w-full relative mb-8">
+        <div className="w-full h-full relative z-0">
+          <div className="absolute top-0 left-0 w-full h-[200px] md:h-[300px] -z-10">
+            {imgUrl.length === 0 ? (
+              <div className="w-full h-full bg-slate-400"></div>
+            ) : (
+              <Image
+                src={imgUrl}
+                width={1600}
+                height={900}
+                alt="ヘッダー"
+                className="object-cover h-1/2 md:h-full w-full"
+              />
+            )}
+          </div>
+          <div className="w-full pt-[140px] md:pt-[240px] px-4 m-auto md:container">
+            <div className="flex flex-col justify-center items-center w-full">
+              <div className="w-full relative flex md:gap-3 md:mb-8">
+                <MUI.Avatar
+                  alt="icon"
+                  src="https://placehold.jp/300x300.png"
+                  sx={{ width: 150, height: 150 }}
+                  className="shadow-md"
+                />
+                <button className="absolute top-6 right-0  bg-gray-500 text-white text-sm rounded px-2 py-1 md:hidden">
+                  編集
+                </button>
+                <ul className="absolute right-0 bottom-5 flex flex-wrap gap-2 w-1/2 md:hidden">
+                  <li>
+                    <a
+                      href="#"
+                      className="text-white bg-black px-2 py-1 rounded text-sm"
+                      target="_blank"
+                    >
+                      X
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="#"
+                      className="text-white bg-sky-400 px-2 py-1 rounded text-sm"
+                      target="_blank"
+                    >
+                      pixiv
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="#"
+                      className="text-white bg-amber-700 bg-opacity-80 px-2 py-1 rounded text-sm"
+                      target="_blank"
+                    >
+                      ふせったー
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="#"
+                      className="text-white bg-sky-700 px-2 py-1 rounded text-sm"
+                      target="_blank"
+                    >
+                      privatter
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="#"
+                      className="text-white bg-slate-500 px-2 py-1 rounded text-sm"
+                      target="_blank"
+                    >
+                      その他
+                    </a>
+                  </li>
+                </ul>
+                <div className="hidden md:block grid grid-col-2 gap-4 h-[150px] flex-1 relative">
+                  <h3 className="text-3xl font-semibold flex justify-start items-end h-1/3">
+                    ユーザー名
+                  </h3>
+                  <ul className="flex flex-wrap gap-2 mt-4 h-1/3">
+                    <li>
+                      <a
+                        href="#"
+                        className="text-white bg-black px-2 py-1 rounded text-sm"
+                        target="_blank"
+                      >
+                        X
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="#"
+                        className="text-white bg-sky-400 px-2 py-1 rounded text-sm"
+                        target="_blank"
+                      >
+                        pixiv
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="#"
+                        className="text-white bg-amber-700 bg-opacity-80 px-2 py-1 rounded text-sm"
+                        target="_blank"
+                      >
+                        ふせったー
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="#"
+                        className="text-white bg-sky-700 px-2 py-1 rounded text-sm"
+                        target="_blank"
+                      >
+                        privatter
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="#"
+                        className="text-white bg-slate-500 px-2 py-1 rounded text-sm"
+                        target="_blank"
+                      >
+                        その他
+                      </a>
+                    </li>
+                  </ul>
+                  <button className="absolute bottom-0 left-0 bg-gray-500 text-white text-sm rounded px-2 py-1">
+                    編集
+                  </button>
+                </div>
+              </div>
+              <h3 className="text-xl font-semibold my-4 md:hidden">
+                ユーザー名
+              </h3>
+              <div className="bg-white p-5 rounded">
+                <UI.Collapse>
+                  プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィープロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィープロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文
+                </UI.Collapse>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+      <article>
+        <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
+          <UI.Tabs />
+        </section>
+        <section className="container my-2 m-auto">
+          <div className="grid grid-cols-2 md:mx-auto md:grid-cols-4 mx-2 gap-1">
+            {illusts.map((illust: IndexIllustData) => (
+              <div key={illust.id}>
+                <Illust illust={illust} isUserPage={false} />
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="mt-4 mb-16">
+          <UI.Pagination elementName="#tabs" adjust={-10} />
+        </section>
+      </article>
+    </>
+  );
 }

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -18,13 +18,14 @@ const illusts = Array.from({ length: 20 }).map((_, i) => ({
 }));
 
 export default function UserPage() {
-  const imgUrl = "https://placehold.jp/1600x900.png";
+  const imgUrl = ""; // TODO : ユーザーヘッダーのURLを取得
 
   return (
     <>
       <article className="w-full relative mb-8">
-        <div className="w-full h-full relative z-0">
-          <div className="absolute top-0 left-0 w-full h-[200px] md:h-[300px] -z-10">
+        <section className="w-full h-full relative z-0">
+          {/* ヘッダー画像 */}
+          <div className="absolute top-0 left-0 w-full h-[180px] md:h-[300px] -z-10">
             {imgUrl.length === 0 ? (
               <div className="w-full h-full bg-slate-400"></div>
             ) : (
@@ -33,23 +34,35 @@ export default function UserPage() {
                 width={1600}
                 height={900}
                 alt="ヘッダー"
-                className="object-cover h-1/2 md:h-full w-full"
+                className="object-cover h-full w-full"
               />
             )}
           </div>
+
+          {/* ユーザー情報 */}
           <div className="w-full pt-[140px] md:pt-[240px] px-4 m-auto md:container">
             <div className="flex flex-col justify-center items-center w-full">
               <div className="w-full relative flex md:gap-3 md:mb-8">
+                {/* SP */}
                 <MUI.Avatar
                   alt="icon"
-                  src="https://placehold.jp/300x300.png"
-                  sx={{ width: 150, height: 150 }}
-                  className="shadow-md"
+                  src="https://placehold.jp/300x300.png" // TODO : ユーザーアイコンのURLを取得
+                  sx={{ width: 100, height: 100 }}
+                  className="shadow-md md:hidden"
                 />
-                <button className="absolute top-6 right-0  bg-gray-500 text-white text-sm rounded px-2 py-1 md:hidden">
+                {/* PC */}
+                <MUI.Avatar
+                  alt="icon"
+                  src="https://placehold.jp/300x300.png" // TODO : ユーザーアイコンのURLを取得
+                  sx={{ width: 150, height: 150 }}
+                  className="hidden shadow-md md:block"
+                />
+
+                {/* SP */}
+                <button className="absolute top-0 right-0  bg-gray-500 text-white text-sm rounded px-2 py-1 md:hidden">
                   編集
                 </button>
-                <ul className="absolute right-0 bottom-5 flex flex-wrap gap-2 w-1/2 md:hidden">
+                <ul className="flex h-1/2 mt-auto ml-2 flex-wrap gap-2 md:hidden">
                   <li>
                     <a
                       href="#"
@@ -96,11 +109,12 @@ export default function UserPage() {
                     </a>
                   </li>
                 </ul>
+                {/* PC */}
                 <div className="hidden md:block grid grid-col-2 gap-4 h-[150px] flex-1 relative">
                   <h3 className="text-3xl font-semibold flex justify-start items-end h-1/3">
                     ユーザー名
                   </h3>
-                  <ul className="flex flex-wrap gap-2 mt-4 h-1/3">
+                  <ul className="flex justify-start items-center flex-wrap gap-2 h-1/3">
                     <li>
                       <a
                         href="#"
@@ -152,9 +166,12 @@ export default function UserPage() {
                   </button>
                 </div>
               </div>
+
+              {/* SP */}
               <h3 className="text-xl font-semibold my-4 md:hidden">
                 ユーザー名
               </h3>
+
               <div className="bg-white p-5 rounded">
                 <UI.Collapse>
                   プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィープロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィープロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文
@@ -162,8 +179,10 @@ export default function UserPage() {
               </div>
             </div>
           </div>
-        </div>
+        </section>
       </article>
+
+      {/* イラスト一覧 */}
       <article>
         <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
           <UI.Tabs />
@@ -178,7 +197,7 @@ export default function UserPage() {
           </div>
         </section>
         <section className="mt-4 mb-16">
-          <UI.Pagination elementName="#tabs" adjust={-10} />
+          <UI.Pagination elementName="#tabs" adjust={-20} />
         </section>
       </article>
     </>

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -3,6 +3,7 @@ import * as MUI from "@mui/material";
 import * as UI from "@/components/ui";
 import { IndexIllustData } from "@/types";
 import { Illust } from "@/components/illusts";
+import { useTranslations } from "next-intl";
 
 // 仮データをハードコーディング
 const illusts = Array.from({ length: 20 }).map((_, i) => ({
@@ -19,6 +20,8 @@ const illusts = Array.from({ length: 20 }).map((_, i) => ({
 
 export default function UserPage() {
   const imgUrl = ""; // TODO : ユーザーヘッダーのURLを取得
+  const t_General = useTranslations("General");
+  const t_UserPage = useTranslations("UserPage");
 
   return (
     <>
@@ -33,7 +36,7 @@ export default function UserPage() {
                 src={imgUrl}
                 width={1600}
                 height={900}
-                alt="ヘッダー"
+                alt={t_UserPage("headerImage")}
                 className="object-cover h-full w-full"
               />
             )}
@@ -45,14 +48,14 @@ export default function UserPage() {
               <div className="w-full relative flex md:gap-3 md:mb-8">
                 {/* SP */}
                 <MUI.Avatar
-                  alt="icon"
+                  alt={t_UserPage("avatar")}
                   src="https://placehold.jp/300x300.png" // TODO : ユーザーアイコンのURLを取得
                   sx={{ width: 100, height: 100 }}
                   className="shadow-md md:hidden"
                 />
                 {/* PC */}
                 <MUI.Avatar
-                  alt="icon"
+                  alt={t_UserPage("avatar")}
                   src="https://placehold.jp/300x300.png" // TODO : ユーザーアイコンのURLを取得
                   sx={{ width: 150, height: 150 }}
                   className="hidden shadow-md md:block"
@@ -60,7 +63,7 @@ export default function UserPage() {
 
                 {/* SP */}
                 <button className="absolute top-0 right-0  bg-gray-500 text-white text-sm rounded px-2 py-1 md:hidden">
-                  編集
+                  {t_General("edit")}
                 </button>
                 <ul className="flex h-1/2 mt-auto ml-2 flex-wrap gap-2 md:hidden">
                   <li>
@@ -87,7 +90,7 @@ export default function UserPage() {
                       className="text-white bg-amber-700 bg-opacity-80 px-2 py-1 rounded text-sm"
                       target="_blank"
                     >
-                      ふせったー
+                      {t_UserPage("fusetter")}
                     </a>
                   </li>
                   <li>
@@ -105,7 +108,7 @@ export default function UserPage() {
                       className="text-white bg-slate-500 px-2 py-1 rounded text-sm"
                       target="_blank"
                     >
-                      その他
+                      {t_UserPage("other")}
                     </a>
                   </li>
                 </ul>
@@ -162,7 +165,7 @@ export default function UserPage() {
                     </li>
                   </ul>
                   <button className="absolute bottom-0 left-0 bg-gray-500 text-white text-sm rounded px-2 py-1">
-                    編集
+                    {t_General("edit")}
                   </button>
                 </div>
               </div>

--- a/front/src/app/admin/layout.tsx
+++ b/front/src/app/admin/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import "@/app/globals.css";
+import "@/styles/globals.css";
 
 export const metadata: Metadata = {
   title: "管理者用 | AStoryer - あすとりや -",

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/front/src/components/illusts/illust.tsx
+++ b/front/src/components/illusts/illust.tsx
@@ -3,7 +3,13 @@ import { IndexIllustData } from "@/types";
 import Image from "next/image";
 import CollectionsIcon from "@mui/icons-material/Collections";
 
-export default function Illust({ illust }: { illust: IndexIllustData }) {
+export default function Illust({
+  illust,
+  isUserPage = true,
+}: {
+  illust: IndexIllustData;
+  isUserPage?: boolean;
+}) {
   return (
     <section>
       <Link href={`/illusts/${illust.id}`} className="relative z-0">
@@ -19,20 +25,22 @@ export default function Illust({ illust }: { illust: IndexIllustData }) {
           <CollectionsIcon className="absolute bottom-2 right-2 text-white" />
         )}
       </Link>
-      <div className="mt-2 flex justify-start items-center gap-3">
-        <Link href={`/users/${illust.user.id}`}>
-          <Image
-            src={illust.user.avatar}
-            width={40}
-            height={40}
-            alt={illust.user.name}
-            className="rounded-full aspect-square object-cover"
-          />
-        </Link>
-        <h4>
-          <Link href={`/illusts/${illust.id}`}>{illust.title}</Link>
-        </h4>
-      </div>
+      {isUserPage && (
+        <div className="mt-2 flex justify-start items-center gap-3">
+          <Link href={`/users/${illust.user.id}`}>
+            <Image
+              src={illust.user.avatar}
+              width={40}
+              height={40}
+              alt={illust.user.name}
+              className="rounded-full aspect-square object-cover"
+            />
+          </Link>
+          <h4>
+            <Link href={`/illusts/${illust.id}`}>{illust.title}</Link>
+          </h4>
+        </div>
+      )}
     </section>
   );
 }

--- a/front/src/components/illusts/illustCarousel.tsx
+++ b/front/src/components/illusts/illustCarousel.tsx
@@ -34,13 +34,7 @@ export default function IllustCarousel({
     <Swiper
       modules={[Navigation, Autoplay]}
       breakpoints={slideSettings}
-      loop={true}
       speed={5000}
-      centeredSlides={true}
-      autoplay={{
-        delay: 4000,
-        disableOnInteraction: false,
-      }}
       navigation
       className="w-full"
     >

--- a/front/src/components/illusts/illustCarousel.tsx
+++ b/front/src/components/illusts/illustCarousel.tsx
@@ -5,7 +5,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
-import "@/styles/index.css";
+import "@/styles/globals.css"; // swiperの上書き
 import { IndexIllustData } from "@/types";
 import Illust from "./illust";
 

--- a/front/src/components/layouts/mainLayout.tsx
+++ b/front/src/components/layouts/mainLayout.tsx
@@ -12,7 +12,7 @@ export default function MainLayout({
         <Headers />
       </div>
 
-      <main className="w-full flex-1">{children}</main>
+      <main className="w-full flex-1 relative">{children}</main>
 
       <div className="w-full bg-slate-500">
         <Footers />

--- a/front/src/components/ui/collapse.tsx
+++ b/front/src/components/ui/collapse.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import Style from "@/styles/index.module.css";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import * as MUI from "@mui/material";
+
+export default function Collapse({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState<boolean>(false);
+  return (
+    <>
+      <MUI.Collapse
+        in={open}
+        collapsedSize={100}
+        className={open ? "" : Style.gradientText}
+      >
+        {children}
+      </MUI.Collapse>
+      <div className="w-full text-center mt-4">
+        <button
+          type="button"
+          className="w-full bg-green-400 border border-green-600 bg-opacity-50 rounded"
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/front/src/components/ui/index.ts
+++ b/front/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import { TransitionsModal, SearchModal, RequiredLoginModal } from "./modal";
 import H2 from "./headTag";
 import LoginWith from "./loginWith";
@@ -6,6 +7,9 @@ import {
   IconButtonList,
   FixedIconButtonList,
 } from "./iconsButton/iconButtonList";
+import Collapse from "./collapse";
+import Tabs from "./tabs";
+import Pagination from "./pagination";
 
 export {
   TransitionsModal,
@@ -16,4 +20,7 @@ export {
   IconButtonList,
   FixedIconButtonList,
   RequiredLoginModal,
+  Collapse,
+  Tabs,
+  Pagination,
 };

--- a/front/src/components/ui/pagination.tsx
+++ b/front/src/components/ui/pagination.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as MUI from "@mui/material";
+import { useEffect, useState } from "react";
+
+export default function Pagination({
+  elementName,
+  adjust = 0,
+}: {
+  elementName?: string;
+  adjust: number;
+}) {
+  const [page, setPage] = useState(1);
+  const [topPosY, setTopPosY] = useState<number>(0);
+
+  useEffect(() => {
+    if (elementName === undefined) return;
+    const element = document.querySelector(elementName);
+    if (element === null) return;
+    setTopPosY(element.getBoundingClientRect().top);
+  }, []);
+
+  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+    window.scrollTo({
+      top: topPosY + adjust,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <article className="w-full m-auto text-center">
+      <div className="md:hidden">
+        <MUI.Pagination
+          count={11}
+          defaultPage={1}
+          size="medium"
+          className="inline-block"
+          onChange={handleChange}
+          page={page}
+        />
+      </div>
+      <div className="hidden md:block">
+        <MUI.Pagination
+          count={11}
+          defaultPage={1}
+          size="large"
+          className="inline-block"
+          onChange={handleChange}
+          page={page}
+        />
+      </div>
+    </article>
+  );
+}

--- a/front/src/components/ui/pagination.tsx
+++ b/front/src/components/ui/pagination.tsx
@@ -22,6 +22,7 @@ export default function Pagination({
 
   const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
+    // TODO : プロフィール文章を表示しているとずれる
     window.scrollTo({
       top: topPosY + adjust,
       behavior: "smooth",
@@ -30,6 +31,7 @@ export default function Pagination({
 
   return (
     <article className="w-full m-auto text-center">
+      {/* SP */}
       <div className="md:hidden">
         <MUI.Pagination
           count={11}
@@ -40,6 +42,8 @@ export default function Pagination({
           page={page}
         />
       </div>
+
+      {/* PC */}
       <div className="hidden md:block">
         <MUI.Pagination
           count={11}

--- a/front/src/components/ui/tabs.tsx
+++ b/front/src/components/ui/tabs.tsx
@@ -1,0 +1,26 @@
+"use client";
+import * as MUI_LAB from "@mui/lab";
+import * as MUI from "@mui/material";
+import { useState } from "react";
+
+enum Tab {
+  post = "myPage",
+  bookmark = "bookmark",
+}
+
+export default function Tabs() {
+  const [value, setValue] = useState(Tab.post);
+
+  const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {
+    setValue(newValue as Tab);
+  };
+
+  return (
+    <MUI_LAB.TabContext value={value}>
+      <MUI_LAB.TabList aria-label="一覧切り替え" onChange={handleChange}>
+        <MUI.Tab label="投稿一覧" value={Tab.post} />
+        <MUI.Tab label="ブックマーク一覧" value={Tab.bookmark} />
+      </MUI_LAB.TabList>
+    </MUI_LAB.TabContext>
+  );
+}

--- a/front/src/components/ui/toggleSort.tsx
+++ b/front/src/components/ui/toggleSort.tsx
@@ -34,7 +34,7 @@ export default function ToggleSort({ searchWords }: { searchWords: string[] }) {
   ) => {
     setSortBy(newSortBy);
     const query =
-      (searchWords.length > 0 && `search=${searchWords.join(",")}`) +
+      ((searchWords?.length ?? 0) > 0 && `search=${searchWords.join(",")}`) +
       (newSortBy === SortBy.New ? "" : "&sortBy=old");
     router.push(`/illusts?${query}`);
   };

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -7,4 +7,5 @@ export const RouterPath = {
   signUp: "/signup",
   login: "/login",
   illustIndex: "/",
+  myPage: (id: number) => `/users/${id}`,
 };

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* swiperのスタイリング */
 .swiper-button-prev,
 .swiper-button-next {

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -378,6 +378,19 @@
   dependencies:
     "@babel/runtime" "^7.24.4"
 
+"@mui/lab@^5.0.0-alpha.170":
+  version "5.0.0-alpha.170"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.170.tgz#4519dfc8d1c51ca54fb9d8b91b95a3733d07be16"
+  integrity sha512-0bDVECGmrNjd3+bLdcLiwYZ0O4HP5j5WSQm5DV6iA/Z9kr8O6AnvZ1bv9ImQbbX7Gj3pX4o43EKwCutj3EQxQg==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/base" "5.0.0-beta.40"
+    "@mui/system" "^5.15.15"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    clsx "^2.1.0"
+    prop-types "^15.8.1"
+
 "@mui/material@^5.15.15":
   version "5.15.15"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.15.tgz#e3ba35f50b510aa677cec3261abddc2db7b20b59"
@@ -2889,6 +2902,7 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
# 概要
ユーザーページのガワを作成しました。
ハードコーディングで表示確認しております。

## 実装項目
- [x] ヘッダーが表示されること
- [x] アイコンが表示されること
- [x] ユーザー名が表示されること
- [x] ユーザープロフィールが表示されること
- [x] サービスのリンクが表示されること
- [ ] 上記ユーザー名以外の記入がないときにレイアウト崩れが起きないこと
   ⇨見積もり時間を越えてしまっているので、バック連携時に適宜対応します
- [x] 投稿作品タブで投稿作品一覧が表示されること
- [x] ブックマーク一覧でブックマーク一覧が表示されること
- [ ] 表示件数が一定以上の場合はページネーションが表示されること
   ⇨ページネーションは実装済みですが表示の切り替えはバック連携時に対応します
- [ ] ページネーションで次ページが表示されること
   ⇨表示の切り替えはバック連携時に対応します

## 実装状況
| PC | SP |
| ---- | ---- |
| <img src="https://i.gyazo.com/a0e797d92caa17a5b003acb19f01fba2.gif" width="430px" /> | <img src="https://i.gyazo.com/c7783dd4d2ad7f80590a82e2d3ab73d5.gif" width="175px" /> |

## 補足
Windows及び検証ツールでレスポンシブを確認しており、iOSでレイアウト崩れが起きないか確認できていません。
px指定しているところが多々あるため、要チェックと修正を必要あれば別途issueで対応します。

## 課題点
ページネーションでスムーススクロールを実装していますが、プロフィール文を全文表示しているとズレます。
投稿一覧とブックマークのタブをスムーズに切り替えていますが、データフェッチが入りラグが生じる可能性があるので、スムーズさはいらないかもしれません。
