### PR TITLE
【feature】アカウント設定の連携 close #42

### DIFF
--- a/back/app/controllers/api/v1/accounts_controller.rb
+++ b/back/app/controllers/api/v1/accounts_controller.rb
@@ -13,11 +13,13 @@ class Api::V1::AccountsController < Api::V1::BasesController
     account = current_api_v1_user.authentications.map do |authentication|
       if(authentication.provider == 'email')
         {
+          "name"=> current_api_v1_user.name,
           # プロバイダーをキーとしてメールアドレスをマージ
           authentication.provider => authentication.uid
         }
       else
         {
+          "name"=> current_api_v1_user.name,
           # メールアドレス以外はuidが不要なのでenabledをマージ
           authentication.provider => "enabled"
         }

--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -31,10 +31,10 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
 
             resource.save!
 
-            response.headers['uid'] = resource.uid
-            response.headers['client'] = client_id
-            response.headers['expiry'] = expiry
-            response.headers['access-token'] = token
+            response.headers['Uid'] = resource.uid
+            response.headers['Client'] = client_id
+            response.headers['Expiry'] = expiry
+            response.headers['Access-Token'] = token
 
             # 認証トークンとユーザー情報を含むJSONを返す
             render json: {

--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
             } and return
           else
             # アカウントがまだ有効でない場合の処理
-            render json: { success: false, message: "アカウントが有効ではありません。" } and return
+            render json: { success: false, message: "アカウントが有効ではありません。" }  and return
           end
         else
           # ユーザーの保存に失敗した場合

--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
   wrap_parameters false
 
+  def create
+    super
+  end
+
   protected
 
   # ログイン成功時の処理オーバーライド

--- a/back/config/initializers/cors.rb
+++ b/back/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      expose: ['access-token', 'expiry', 'uid', 'client']
   end
 end

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -58,7 +58,8 @@
     "newPosts": "新着順",
     "oldPosts": "投稿順",
     "sortBy": "表示順",
-    "edit": "編集"
+    "edit": "編集",
+    "save": "保存"
   },
   "Search": {
     "searchResult": "検索結果",

--- a/front/package.json
+++ b/front/package.json
@@ -26,7 +26,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.2.0",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -1,3 +1,0 @@
-import { useAuth } from "./auth";
-
-export { useAuth };

--- a/front/src/app/[locale]/account/[id]/page.tsx
+++ b/front/src/app/[locale]/account/[id]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { client } from "@/auth";
+import useSWR from "swr";
 import * as Mantine from "@mantine/core";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -19,7 +21,11 @@ const noticeStatesDummy = {
   },
 };
 
+const fetcher = (url: string) => client.get(url).then((res) => res.data);
+
 export default function AccountPage() {
+  const { data, error } = useSWR("/account", fetcher);
+  console.log(data, error);
   const t_AccountSettings = useTranslations("AccountSettings");
   const [noticeStates, setNoticeStates] =
     useState<NoticeStates>(noticeStatesDummy);

--- a/front/src/app/[locale]/layout.tsx
+++ b/front/src/app/[locale]/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   params: { locale: string };
 }>) {
   return (
-    <html lang="ja">
+    <html lang={locale}>
       <head>
         <ColorSchemeScript />
       </head>

--- a/front/src/app/[locale]/login/page.tsx
+++ b/front/src/app/[locale]/login/page.tsx
@@ -6,7 +6,7 @@ import * as MantineForm from "@mantine/form";
 import * as Mantine from "@mantine/core";
 import * as UI from "@/components/ui";
 import { RouterPath } from "@/settings";
-import { useAuth } from "@/api";
+import { useAuth } from "@/auth";
 import { useSetRecoilState } from "recoil";
 import { userState } from "@/recoilState";
 import { useState } from "react";
@@ -31,7 +31,8 @@ export default function LoginPage() {
     },
   });
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const { email, password } = form.getValues();
     const result = await login(email, password);
 

--- a/front/src/app/[locale]/signup/page.tsx
+++ b/front/src/app/[locale]/signup/page.tsx
@@ -5,7 +5,7 @@ import { Link, useRouter } from "@/lib";
 import * as MantineForm from "@mantine/form";
 import * as Mantine from "@mantine/core";
 import * as UI from "@/components/ui";
-import { useAuth } from "@/api";
+import { useAuth } from "@/auth";
 import { RouterPath } from "@/settings";
 import { useSetRecoilState } from "recoil";
 import { userState } from "@/recoilState";
@@ -41,7 +41,8 @@ export default function SignUpPage() {
     },
   });
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const { name, email, password, password_confirmation } = form.getValues();
     const result = await signUp(name, email, password, password_confirmation);
 

--- a/front/src/auth/client.ts
+++ b/front/src/auth/client.ts
@@ -1,0 +1,29 @@
+import { Settings } from "@/settings";
+import axios from "axios";
+
+const API_URL = Settings.API_URL;
+
+export const client = axios.create({
+  baseURL: API_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+client.interceptors.request.use((config) => {
+  if (typeof window === "undefined") return config;
+
+  const accessToken = localStorage.getItem("access-token");
+  const client = localStorage.getItem("client");
+  const uid = localStorage.getItem("uid");
+  const expiry = localStorage.getItem("expiry");
+
+  if (accessToken && client && uid && expiry) {
+    config.headers["access-token"] = accessToken;
+    config.headers.client = client;
+    config.headers.uid = uid;
+    config.headers.expiry = expiry;
+  }
+
+  return config;
+});

--- a/front/src/auth/client.ts
+++ b/front/src/auth/client.ts
@@ -13,16 +13,16 @@ export const client = axios.create({
 client.interceptors.request.use((config) => {
   if (typeof window === "undefined") return config;
 
-  const accessToken = localStorage.getItem("access-token");
-  const client = localStorage.getItem("client");
-  const uid = localStorage.getItem("uid");
-  const expiry = localStorage.getItem("expiry");
+  const accessToken = localStorage.getItem("Access-Token");
+  const client = localStorage.getItem("Client");
+  const uid = localStorage.getItem("Uid");
+  const expiry = localStorage.getItem("Expiry");
 
   if (accessToken && client && uid && expiry) {
-    config.headers["access-token"] = accessToken;
-    config.headers.client = client;
-    config.headers.uid = uid;
-    config.headers.expiry = expiry;
+    config.headers["Access-Token"] = accessToken;
+    config.headers["Client"] = client;
+    config.headers["Uid"] = uid;
+    config.headers["Expiry"] = expiry;
   }
 
   return config;

--- a/front/src/auth/index.ts
+++ b/front/src/auth/index.ts
@@ -1,0 +1,4 @@
+import { useAuth } from "./useAuth";
+import { client } from "./client";
+
+export { useAuth, client };

--- a/front/src/auth/useAuth.ts
+++ b/front/src/auth/useAuth.ts
@@ -17,11 +17,12 @@ export const useAuth = () => {
       clearAccessTokens();
       return { success: false, message: data.message };
     }
+    console.log(response.headers.get("Access-Token"));
     setAccessTokens(
-      response.headers.get("access-token") || "",
-      response.headers.get("client") || "",
-      response.headers.get("uid") || "",
-      response.headers.get("expiry") || ""
+      response.headers.get("Access-Token") || "",
+      response.headers.get("Client") || "",
+      response.headers.get("Uid") || "",
+      response.headers.get("Expiry") || ""
     );
 
     return {
@@ -56,10 +57,10 @@ export const useAuth = () => {
     }
 
     setAccessTokens(
-      response.headers.get("access-token") || "",
-      response.headers.get("client") || "",
-      response.headers.get("uid") || "",
-      response.headers.get("expiry") || ""
+      response.headers.get("Access-Token") || "",
+      response.headers.get("Client") || "",
+      response.headers.get("Uid") || "",
+      response.headers.get("Expiry") || ""
     );
     return {
       success: true,
@@ -73,17 +74,17 @@ export const useAuth = () => {
     uid: string,
     expiry: string
   ) => {
-    localStorage.setItem("access-token", accessToken);
-    localStorage.setItem("client", client);
-    localStorage.setItem("uid", uid);
-    localStorage.setItem("expiry", expiry);
+    localStorage.setItem("Access-Token", accessToken);
+    localStorage.setItem("Client", client);
+    localStorage.setItem("Uid", uid);
+    localStorage.setItem("Expiry", expiry);
   };
 
   const clearAccessTokens = () => {
-    localStorage.removeItem("access-token");
-    localStorage.removeItem("client");
-    localStorage.removeItem("uid");
-    localStorage.removeItem("expiry");
+    localStorage.removeItem("Access-Token");
+    localStorage.removeItem("Client");
+    localStorage.removeItem("Uid");
+    localStorage.removeItem("Expiry");
   };
 
   return { login, signUp };

--- a/front/src/auth/useAuth.ts
+++ b/front/src/auth/useAuth.ts
@@ -12,20 +12,22 @@ export const useAuth = () => {
     });
 
     const data = await response.json();
-    if (response.ok && data.success) {
-      setAccessTokens(
-        response.headers.get("access-token") || "",
-        response.headers.get("client") || "",
-        response.headers.get("uid") || "",
-        response.headers.get("expiry") || ""
-      );
-      return {
-        success: true,
-        user: { id: data.user.id, name: data.user.name } as IUser,
-      };
-    }
 
-    return { success: false, message: data.message };
+    if (!response.ok || !data.success) {
+      clearAccessTokens();
+      return { success: false, message: data.message };
+    }
+    setAccessTokens(
+      response.headers.get("access-token") || "",
+      response.headers.get("client") || "",
+      response.headers.get("uid") || "",
+      response.headers.get("expiry") || ""
+    );
+
+    return {
+      success: true,
+      user: { id: data.user.id, name: data.user.name } as IUser,
+    };
   };
 
   const signUp = async (
@@ -48,20 +50,21 @@ export const useAuth = () => {
     });
 
     const data = await response.json();
-    if (response.ok) {
-      setAccessTokens(
-        response.headers.get("access-token") || "",
-        response.headers.get("client") || "",
-        response.headers.get("uid") || "",
-        response.headers.get("expiry") || ""
-      );
-      return {
-        success: true,
-        user: { id: data.user.id, name: data.user.name } as IUser,
-      };
+    if (!response.ok || !data.success) {
+      clearAccessTokens();
+      return { success: false, message: data.message };
     }
 
-    return { success: false, message: data.message };
+    setAccessTokens(
+      response.headers.get("access-token") || "",
+      response.headers.get("client") || "",
+      response.headers.get("uid") || "",
+      response.headers.get("expiry") || ""
+    );
+    return {
+      success: true,
+      user: { id: data.user.id, name: data.user.name } as IUser,
+    };
   };
 
   const setAccessTokens = (

--- a/front/src/components/features/users/index.ts
+++ b/front/src/components/features/users/index.ts
@@ -1,4 +1,5 @@
 import UserTabs from "./userTabs";
 import UserEdit from "./edit";
+import NoticeTabs from "./notice";
 
-export { UserTabs, UserEdit };
+export { UserTabs, UserEdit, NoticeTabs };

--- a/front/src/components/features/users/notice.tsx
+++ b/front/src/components/features/users/notice.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { NoticeState, NoticeStates } from "@/types";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import * as Mantine from "@mantine/core";
+
+enum NoticeType {
+  app = "app",
+  email = "email",
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: string;
+  value: string;
+  noticeState: NoticeState;
+  setNewNoticeState: React.Dispatch<React.SetStateAction<NoticeStates>>;
+}
+
+export default function NoticeTabs({
+  noticeStates,
+}: {
+  noticeStates: NoticeStates;
+}) {
+  const [value, setValue] = useState<string>(NoticeType.app);
+  const t_AccountSettings = useTranslations("AccountSettings");
+  const [newNoticeState, setNewNoticeState] =
+    useState<NoticeStates>(noticeStates);
+
+  const handleChange = (newValue: string | null) => {
+    if (newValue === value) return;
+
+    if (newValue === null) {
+      setValue(NoticeType.app);
+      return;
+    }
+    setValue(newValue);
+  };
+
+  return (
+    <Mantine.Box>
+      <Mantine.Tabs value={value} onChange={handleChange}>
+        <Mantine.Tabs.List
+          aria-label={t_AccountSettings("notificationSettings")}
+        >
+          <Mantine.Tabs.Tab value={NoticeType.app}>
+            {t_AccountSettings("app")}
+          </Mantine.Tabs.Tab>
+          <Mantine.Tabs.Tab value={NoticeType.email}>
+            {t_AccountSettings("mail")}
+          </Mantine.Tabs.Tab>
+        </Mantine.Tabs.List>
+        <Mantine.Tabs.Panel value={NoticeType.app} className="my-5">
+          <NoticePanel
+            value={value}
+            index={NoticeType.app}
+            noticeState={newNoticeState.app}
+            setNewNoticeState={setNewNoticeState}
+          />
+        </Mantine.Tabs.Panel>
+        <Mantine.Tabs.Panel value={NoticeType.email} className="my-5">
+          <NoticePanel
+            value={value}
+            index={NoticeType.email}
+            noticeState={newNoticeState.email}
+            setNewNoticeState={setNewNoticeState}
+          />
+        </Mantine.Tabs.Panel>
+      </Mantine.Tabs>
+    </Mantine.Box>
+  );
+}
+
+function NoticePanel(props: TabPanelProps) {
+  const { value, index, noticeState, setNewNoticeState, ...other } = props;
+  const t_AccountSettings = useTranslations("AccountSettings");
+
+  const handleChange = (key: string, value: boolean) => {
+    const newNoticeState = {
+      ...noticeState,
+      [key]: value,
+    };
+    setNewNoticeState((prevState) => ({
+      ...prevState,
+      [index]: newNoticeState,
+    }));
+  };
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`tabpanel-${index}`}
+      aria-labelledby={`tab-${index}`}
+      {...other}
+      className="flex flex-col gap-2"
+    >
+      {value === index && (
+        <>
+          <Mantine.Switch
+            label={t_AccountSettings("favorite")}
+            checked={noticeState.favorite}
+            onChange={() => handleChange("favorite", !noticeState.favorite)}
+          />
+          <Mantine.Switch
+            label={t_AccountSettings("bookmark")}
+            checked={noticeState.bookmark}
+            onChange={() => handleChange("bookmark", !noticeState.bookmark)}
+          />
+          <Mantine.Switch
+            label={t_AccountSettings("comment")}
+            checked={noticeState.comment}
+            onChange={() => handleChange("comment", !noticeState.comment)}
+          />
+          <Mantine.Switch
+            label={t_AccountSettings("follow")}
+            checked={noticeState.follower}
+            onChange={() => handleChange("follow", !noticeState.follower)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -26,3 +26,15 @@ export enum PublicState {
   PUBLIC = 2, // 全体公開
   ONLY_URL = 3, // URLを知ってる人のみ
 }
+
+export interface NoticeState {
+  favorite: boolean;
+  bookmark: boolean;
+  comment: boolean;
+  follower: boolean;
+}
+
+export interface NoticeStates {
+  app: NoticeState;
+  email: NoticeState;
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -31,7 +31,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "src/auth/useAuth.ts"
   ],
   "exclude": [
     "node_modules"

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -947,7 +947,7 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -3110,6 +3110,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
+  integrity sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==
+  dependencies:
+    client-only "^0.0.1"
+    use-sync-external-store "^1.2.0"
+
 tabbable@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
@@ -3331,6 +3339,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# 概要
バックエンドで設定した通知設定・アカウント名・登録メールアドレスを表示する実装をしました。

## 実装項目
- [x] 基本通知設定を取得して表示されていること
- [x] 通知の設定を取得して表示されていること
   - [x] アプリ内通知の設定を取得して表示されていること
   - [x] メール通知の設定を取得して表示されていること

## 追加実装項目
- [x] SWRの導入
- [x] アカウント名の表示
- [x] メールアドレスの表示
- [x] 軽度なリファクタリング（コンポーネントの切り分け）

## 挙動
画面左がアプリ、画面右がPostmanで取得したデータです。
| アプリ通知設定 | メール通知設定 |
| --- | --- |
| <img src="https://i.gyazo.com/b03ba9567cef3075c1174eeb2ba93079.png" width="400px" /> | <img src="https://i.gyazo.com/ba0fd09c227d52975b441084fd576422.png" width="400px" /> |

## 備考
そもそも通知の実装をissueに切っていないので、MVPリリース段階では入れず後回しにする可能性があります。