### PR TITLE
【feature】バックのアカウント設定更新を実装 close #43

### DIFF
--- a/back/app/controllers/api/v1/accounts_controller.rb
+++ b/back/app/controllers/api/v1/accounts_controller.rb
@@ -28,4 +28,33 @@ class Api::V1::AccountsController < Api::V1::BasesController
 
     render json: {account: account,notices: notices}, status: :ok
   end
+
+  def update
+    begin
+      user = current_api_v1_user
+      if account_params[:email].present?
+        # 認証情報の更新
+        authentication = current_api_v1_user.authentications.find_by(provider: 'email')
+        authentication.update!(uid: account_params[:email])
+        # ユーザーが持っているuidの更新
+        # TODO : 将来的にメールアドレスではなくuuidを使うようにしたい
+        user.uid = account_params[:email]
+        user.email = account_params[:email]
+      end
+
+      if account_params[:name].present?
+        user.name = account_params[:name]
+      end
+      user.save!
+      head :ok
+    rescue
+      head :bad_request
+    end
+  end
+
+  private
+
+  def account_params
+    params.permit(:name, :email)
+  end
 end

--- a/back/app/controllers/api/v1/notices_controller.rb
+++ b/back/app/controllers/api/v1/notices_controller.rb
@@ -1,10 +1,18 @@
 class Api::V1::NoticesController < Api::V1::BasesController
   def update
-    notice = current_user.notices.find(notice_params[:id])
-    begin
-      notice.update!(notice_params.except(:id))
+    success = true
+    notice_params.each do |notice_param|
+      notice = current_api_v1_user.notices.find(notice_param["id"])
+      begin
+        notice.update!(notice_param.except("id"))
+      rescue
+        success = false
+      end
+    end
+
+    if success
       head :ok
-    rescue
+    else
       head :bad_request
     end
   end
@@ -12,6 +20,10 @@ class Api::V1::NoticesController < Api::V1::BasesController
   private
 
   def notice_params
-    params.permit(:id, %i[favorite bookmark comment follower])
+    # 配列が来るので_jsonを使う
+    # リクエストボディがapplication/jsonのときRailsが自動でパースしてくれる、その時使うのが_json
+    params.require(:_json).map do |param|
+      param.permit(:favorite, :bookmark, :comment, :follower, :id)
+    end
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
         sessions:           'api/v1/auth/sessions',
         registrations:       'api/v1/auth/registrations'
       }
-      resource :account, only: %i[show]
+      resource :account, only: %i[show update]
       resource :notice, only: %i[update]
     end
   end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         registrations:       'api/v1/auth/registrations'
       }
       resource :account, only: %i[show]
+      resource :notice, only: %i[update]
     end
   end
 end


### PR DESCRIPTION
# 概要
バックエンドで、アカウント名・メールアドレス・通知の更新処理を実装しました。
Postmanで確認済みです

## 実装項目
- [x] 基本設定を更新できる
   - [x] アカウント名を更新できる
   - [x] メールアドレスを更新できる
- [x] 通知設定を更新できる
   - [x] アプリ内通知一覧を更新できる
      - [x] いいねされたときの通知設定を更新できる
      - [x] ブックマークされたときの通知設定を更新できる
      - [x] コメントされたときの通知設定を更新できる
      - [x] フォローされたときの通知設定を更新できる
   - [x] メール通知一覧を更新できる
      - [x] いいねされたときの通知設定を更新できる
      - [x] ブックマークされたときの通知設定を更新できる
      - [x] コメントされたときの通知設定を更新できる
      - [x] フォローされたときの通知設定を更新できる

## 挙動
画面左がターミナル、右がPostmanで送信したデータです。
ターミナルは上側にあるのがもともと這入っていたデータで、下側が更新されているデータです。
| アカウント名・メールアドレス | 通知設定 |
| --- | --- |
| <img src="https://i.gyazo.com/703474d51ddf5c7cf16c25eb4db8d000.png" width="500px" /> | <img src="https://i.gyazo.com/86ab36fde34830876fc1e91fb3234db0.png" width="500px" /> |

## 補足
ユーザーのuidは認証情報で使っています。メールアドレスを認証情報に使っているため、変更すると再ログインの必要が出ます。
また、セキュリティ的な観点からメールアドレスの変更時はメール通知を行い変更するほうが安全かもしれません。
ただそこまで手が回るかわからないので、MVPリリースでは一旦このままで進めていこうと思います。