### PR TITLE
【feature】ヘッダーのフロント・バックを連携 close #24

### DIFF
--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -39,10 +39,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
             # 認証トークンとユーザー情報を含むJSONを返す
             render json: {
               success: true,
-              user:   {
-                id: resource.id,
-                name: resource.name,
-              },
+              user: resource.as_header_json,
               message: "登録が完了しました。", # カスタムメッセージ等
             } and return
           else

--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
   def render_create_success
     render json: {
       success: true,
-      user: { name: @resource.name, id: @resource.id },
+      user: @resource.as_header_json,
     }
   end
 

--- a/back/app/controllers/api/v1/auth/token_validations_controller.rb
+++ b/back/app/controllers/api/v1/auth/token_validations_controller.rb
@@ -3,7 +3,6 @@ class Api::V1::Auth::TokenValidationsController < DeviseTokenAuth::TokenValidati
   protected
 
   def render_validate_token_success
-    Rails.logger.debug(@resource.as_header_json)
     render json: {
       success: true,
       user: @resource.as_header_json

--- a/back/app/controllers/api/v1/auth/token_validations_controller.rb
+++ b/back/app/controllers/api/v1/auth/token_validations_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::Auth::TokenValidationsController < DeviseTokenAuth::TokenValidationsController
+
+  protected
+
+  def render_validate_token_success
+    Rails.logger.debug(@resource.as_header_json)
+    render json: {
+      success: true,
+      user: @resource.as_header_json
+    }
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -44,7 +44,14 @@ class User < ActiveRecord::Base
     end
   end
 
-  def getAuthInfo
-    
+  def as_header_json
+    {
+      id: id,
+      name: name,
+      avatar: profile&.avatar&.url,
+      header_image: profile&.header_image&.url,
+      following_count: following.count || 0,
+      follower_count: followers.count || 0,
+    }
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth',controllers: {
         omniauth_callbacks: 'api/v1/auth/omniauth_callbacks',
         sessions:           'api/v1/auth/sessions',
-        registrations:       'api/v1/auth/registrations'
+        registrations:       'api/v1/auth/registrations',
+        token_validations:  'api/v1/auth/token_validations'
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]

--- a/front/src/app/[locale]/login/page.tsx
+++ b/front/src/app/[locale]/login/page.tsx
@@ -58,13 +58,13 @@ export default function LoginPage() {
             )}
             <Mantine.TextInput
               withAsterisk
-              type="email"
               label={t_Auth("email")}
               autoComplete="email"
               key={form.key("email")}
               {...form.getInputProps("email")}
             />
             <Mantine.TextInput
+              withAsterisk
               label={t_Auth("password")}
               type="password"
               autoComplete="current-password"

--- a/front/src/app/[locale]/signup/page.tsx
+++ b/front/src/app/[locale]/signup/page.tsx
@@ -75,13 +75,13 @@ export default function SignUpPage() {
             />
             <Mantine.TextInput
               withAsterisk
-              type="email"
               label={t_Auth("email")}
               autoComplete="email"
               key={form.key("email")}
               {...form.getInputProps("email")}
             />
             <Mantine.TextInput
+              withAsterisk
               label={t_Auth("password")}
               type="password"
               autoComplete="new-password"
@@ -89,6 +89,7 @@ export default function SignUpPage() {
               {...form.getInputProps("password")}
             />
             <Mantine.TextInput
+              withAsterisk
               type="password"
               label={t_Auth("password_confirmation")}
               autoComplete="new-password"

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -3,35 +3,31 @@ import { Link, useRouter } from "@/lib";
 import * as RecoilState from "@/recoilState";
 import { useTranslations } from "next-intl";
 import React, { useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import Image from "next/image";
-import { RequiredLoginModal } from "@/components/ui";
 import { IoMdSearch, IoMdSettings } from "rocketicons/io";
 import { VscAccount } from "rocketicons/vsc";
 import * as Mantine from "@mantine/core";
 import { FaRegBookmark } from "rocketicons/fa";
 import { MdLogout } from "rocketicons/md";
 import { RouterPath } from "@/settings";
+import { IUser } from "@/types";
 
 export default function Headers() {
   const user = useRecoilValue(RecoilState.userState);
   const t_Header = useTranslations("Header");
   const [search, setSearch] = useState("");
   const router = useRouter();
-  const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (!search) return;
     const searchWords = search.split(/\s|　/).join(",");
-    router.push(`/illusts?search=${searchWords}`);
+    router.push(RouterPath.illustSearch(searchWords));
   };
 
   const handlePost = () => {
-    // TODO : ログインユーザーであれば画面遷移する
-    // router.push("/illusts/post");
-    // TODO : ログインユーザーでなければログインや登録を促す
-    setModalOpen(true);
+    router.push("/illusts/post");
   };
 
   return (
@@ -77,13 +73,16 @@ export default function Headers() {
             </form>
           </div>
           {user.name ? (
-            <Mantine.Button
-              variant="contained"
-              onClick={handlePost}
-              className="hidden md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
-            >
-              {t_Header("postButton")}
-            </Mantine.Button>
+            <>
+              <Mantine.Button
+                variant="contained"
+                onClick={handlePost}
+                className="hidden md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
+              >
+                {t_Header("postButton")}
+              </Mantine.Button>
+              {AccountMenu(user)}
+            </>
           ) : (
             <Link
               href="/login"
@@ -92,15 +91,13 @@ export default function Headers() {
               {t_Header("signUpOrLogin")}
             </Link>
           )}
-          {AccountMenu()}
         </div>
       </header>
-      <RequiredLoginModal />
     </>
   );
 }
 
-function AccountMenu() {
+function AccountMenu(user: IUser) {
   const t_Menu = useTranslations("MyMenu");
   const router = useRouter();
 
@@ -118,7 +115,7 @@ function AccountMenu() {
         <Mantine.Avatar
           alt="icon"
           variant="light"
-          src="https://placehold.jp/300x300.png"
+          src={user.avatar ? user.avatar : "https://placehold.jp/300x300.png"}
           className="cursor-pointer"
           radius="xl"
           size="lg"
@@ -129,36 +126,42 @@ function AccountMenu() {
           <div className="flex justify-center items-center">
             <Mantine.Avatar
               alt="icon"
-              src="https://placehold.jp/300x300.png"
+              src={
+                user.avatar ? user.avatar : "https://placehold.jp/300x300.png"
+              }
               variant="light"
               radius="xl"
               size="lg"
             />
-            <span className="ml-4">ユーザー名</span>
+            <span className="ml-4">{user.name}</span>
           </div>
         </Mantine.Menu.Item>
         <div className="flex justify-center items-center">
-          <Mantine.Menu.Item onClick={() => handleLink("#")}>
+          <Mantine.Menu.Item
+            onClick={() => handleLink(RouterPath.users(user.id))}
+          >
             <div className="flex flex-col justify-center items-center">
               <span className="text-center">{t_Menu("follow")}</span>
-              <span>10</span>
+              <span>{user.follow}</span>
             </div>
           </Mantine.Menu.Item>
-          <Mantine.Menu.Item onClick={() => handleLink("#")}>
+          <Mantine.Menu.Item
+            onClick={() => handleLink(RouterPath.users(user.id))}
+          >
             <div className="flex flex-col justify-center items-center">
               <span>{t_Menu("follower")}</span>
-              <span>10</span>
+              <span>{user.follower}</span>
             </div>
           </Mantine.Menu.Item>
         </div>
         <Mantine.Menu.Item
-          onClick={() => handleLink(RouterPath.users(1))}
+          onClick={() => handleLink(RouterPath.users(user.id))}
           leftSection={<VscAccount />}
         >
           {t_Menu("myPage")}
         </Mantine.Menu.Item>
         <Mantine.Menu.Item
-          onClick={() => handleLink("users/1/bookmarks")}
+          onClick={() => handleLink(RouterPath.bookmark(user.id))}
           leftSection={<FaRegBookmark />}
         >
           {t_Menu("bookmark")}

--- a/front/src/hook/useAuth.ts
+++ b/front/src/hook/useAuth.ts
@@ -1,6 +1,7 @@
 import { Settings } from "@/settings";
 import { IUser } from "@/types";
 
+// TODO : axiosに置き換える
 export const useAuth = () => {
   const login = async (email: string, password: string) => {
     const response = await fetch(`${Settings.API_URL}/auth/sign_in`, {
@@ -26,7 +27,7 @@ export const useAuth = () => {
 
     return {
       success: true,
-      user: { id: data.user.id, name: data.user.name } as IUser,
+      user: data.user as IUser,
     };
   };
 
@@ -63,7 +64,41 @@ export const useAuth = () => {
     );
     return {
       success: true,
-      user: { id: data.user.id, name: data.user.name } as IUser,
+      user: data.user as IUser,
+    };
+  };
+
+  const autoLogin = async () => {
+    const accessToken = localStorage.getItem("Access-Token");
+    const client = localStorage.getItem("Client");
+    const uid = localStorage.getItem("Uid");
+    const expiry = localStorage.getItem("Expiry");
+
+    if (!accessToken || !client || !uid || !expiry) {
+      clearAccessTokens();
+      return { success: false };
+    }
+
+    const response = await fetch(`${Settings.API_URL}/auth/validate_token`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Token": accessToken,
+        Client: client,
+        Uid: uid,
+        Expiry: expiry,
+      },
+    });
+
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      clearAccessTokens();
+      return { success: false };
+    }
+
+    return {
+      success: true,
+      user: data.user as IUser,
     };
   };
 
@@ -86,5 +121,5 @@ export const useAuth = () => {
     localStorage.removeItem("Expiry");
   };
 
-  return { login, signUp };
+  return { login, signUp, autoLogin };
 };

--- a/front/src/recoilState/userState.ts
+++ b/front/src/recoilState/userState.ts
@@ -8,7 +8,7 @@ export const userState = atom<IUser>({
     id: -1,
     name: "",
     avatar: "",
-    follow: 0,
-    follower: 0,
+    following_count: 0,
+    follower_count: 0,
   },
 });

--- a/front/src/recoilState/userState.ts
+++ b/front/src/recoilState/userState.ts
@@ -7,5 +7,8 @@ export const userState = atom<IUser>({
   default: {
     id: -1,
     name: "",
+    avatar: "",
+    follow: 0,
+    follower: 0,
   },
 });

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -7,6 +7,8 @@ export const RouterPath = {
   signUp: "/signup",
   login: "/login",
   illustIndex: "/",
+  illustSearch: (searchWord: string) => `/illusts?search=${searchWord}`,
   users: (id: number) => `/users/${id}`,
   account: "/account",
+  bookmark: (id: number) => `/users/${id}?bookmark=true`,
 };

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -19,8 +19,8 @@ export interface IUser {
   id: number;
   name: string;
   avatar: string;
-  follow: number;
-  follower: number;
+  following_count: number;
+  follower_count: number;
 }
 
 export enum PublicState {

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -18,6 +18,9 @@ export interface ButtonState {
 export interface IUser {
   id: number;
   name: string;
+  avatar: string;
+  follow: number;
+  follower: number;
 }
 
 export enum PublicState {


### PR DESCRIPTION
# 概要
ヘッダー情報をフロントとバックを連携しました

## 実装項目
ログイン済み
- [x] ログインユーザーのアイコンが表示されること
   ⇨ユーザープロフィールの編集のバック・フロント連携後に確認
- [x] ログインユーザーの名前が表示されること
- [x] ログインユーザーのフォロー人数が表示されること
- [x] ログインユーザーのフォロワー人数が表示されること
- [x] マイページでログインユーザーのページへ遷移すること
- [ ] ログアウトボタンでログアウトされ、ホームページへ遷移すること
   ⇨別タスク

ゲストログイン
- [ ] ゲスト用のアイコンが表示されること
- [ ] ユーザー名が「ゲスト」で表示されること
- [ ] フォロー人数が0で表示されること
- [ ] フォロワー人数が0で表示されること
- [ ] マイページで「ログインすると使えます」とログインモーダルが表示されること
- [ ] 設定で「ログインすると使えます」とログインモーダルが表示されること
- [ ] ログアウトボタンでログアウトされ、ホームページへ遷移すること
⇨ゲストログイン機能を廃止、後述

## ゲストログイン機能を排除
今回未ログインでも投稿データが見れるので、ゲストログインを廃止します。
アプリの雰囲気は未ログインでも分かるのではと判断したためです。

## 挙動
<img src="https://i.gyazo.com/0e3ff3dcde1393c4e261cd699ec2e677.gif" width="500px" />