### PR TITLE
【feature】イラスト投稿ページのガワ作成 close #62

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -108,5 +108,32 @@
     "other": "その他",
     "headerImage": "ヘッダー画像",
     "avatar": "ユーザーアイコン"
+  },
+  "PostIllust": {
+    "title": "イラスト投稿",
+    "upload": "イラストアップロード",
+    "uploadValid": "イラストをアップロードしてください"
+  },
+  "PostGeneral": {
+    "title": "タイトル",
+    "caption": "キャプション",
+    "tag": "タグ",
+    "gameSystem": "システム",
+    "synalioTitle": "シナリオ名",
+    "publishRange": "公開範囲",
+    "allPublish": "全体公開",
+    "urlPublish": "URLを知ってる人",
+    "followerPublish": "フォロワー",
+    "private": "非公開",
+    "publishAttention": "※「全体公開」と「URLを知っている人」はログインユーザーでなくても見れます",
+    "post": "投稿",
+    "draftSave": "下書き保存",
+    "posted": "作品を投稿しました",
+    "draftSaved": "下書きを保存しました",
+    "close": "閉じる",
+    "showPost": "作品を見に行く",
+    "XShare": "Xに投稿する",
+    "titleValid": "タイトルを入力してください",
+    "publishValid": "公開範囲を選択してください"
   }
 }

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -10,6 +10,7 @@ import { FixedIconButtonList, IconButtonList } from "@/components/ui";
 import { useTranslations } from "next-intl";
 import { useMediaQuery } from "@mantine/hooks";
 import { MdCollections } from "rocketicons/md";
+import { PublicState } from "@/types";
 
 export default function IllustPage({
   params: { id },
@@ -95,7 +96,7 @@ export default function IllustPage({
                   <IconButtonList
                     postId={id}
                     buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-                    publicState={2} // TODO : 投稿の公開範囲
+                    publicState={PublicState.All} // TODO : 投稿の公開範囲
                   />
                   <h3 className="text-2xl font-semibold">
                     タイトルタイトルタイトルタイトルタイトルタイトルタイトル
@@ -302,7 +303,7 @@ export default function IllustPage({
       <FixedIconButtonList
         postId={id}
         buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-        publicState={2} // TODO : 投稿の公開範囲
+        publicState={PublicState.All} // TODO : 投稿の公開範囲
       />
     </article>
   );

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -8,6 +8,7 @@ import * as Mantine from "@mantine/core";
 import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
 import { useMediaQuery } from "@mantine/hooks";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { FaImage } from "rocketicons/fa";
@@ -29,7 +30,6 @@ const Synalios = Array.from({ length: 50 }).map((_, i) => ({
 }));
 
 enum PublishRange {
-  hidden = "hidden",
   All = "All",
   Draft = "Draft",
   URL = "URL",
@@ -46,27 +46,29 @@ export default function IllustPostPage() {
   const setOpenModal = useSetRecoilState(modalOpenState);
   const router = useRouter();
   const user = useRecoilValue(userState);
+  const t_PostIllust = useTranslations("PostIllust");
+  const t_PostGeneral = useTranslations("PostGeneral");
 
   const form = useForm({
     initialValues: {
       postIllust: postIllust,
       title: "",
-      publishRange: PublishRange.hidden,
+      publishRange: "" as PublishRange,
     },
     validate: {
       postIllust: () => {
         if (postIllust.length === 0) {
-          return "イラストをアップロードしてください";
+          return t_PostIllust("uploadValid");
         }
       },
       title: (value) => {
         if (!value) {
-          return "タイトルを入力してください";
+          return t_PostGeneral("titleValid");
         }
       },
       publishRange: (value) => {
-        if (!value || value === PublishRange.hidden) {
-          return "公開範囲を選択してください";
+        if (!value) {
+          return t_PostGeneral("publishValid");
         }
       },
     },
@@ -103,14 +105,17 @@ export default function IllustPostPage() {
       <article className="mt-8 mb-12">
         <Mantine.Container size={"sm"}>
           <Mantine.Box className="bg-white p-4 px-8 rounded">
-            <h1 className="text-center font-semibold my-4">イラスト投稿</h1>
+            <h1 className="text-center font-semibold my-4">
+              {t_PostIllust("title")}
+            </h1>
             <form
               className="flex flex-col gap-5"
               onSubmit={form.onSubmit(handleSubmit)}
             >
               <section>
                 <label htmlFor="postIllust">
-                  イラストアップロード<span className="text-red-600">*</span>
+                  {t_PostIllust("upload")}
+                  <span className="text-red-600">*</span>
                 </label>
                 <Dropzone
                   name="postIllust"
@@ -157,7 +162,7 @@ export default function IllustPostPage() {
               <section>
                 <Mantine.TextInput
                   withAsterisk
-                  label="タイトル"
+                  label={t_PostGeneral("title")}
                   name="title"
                   {...form.getInputProps("title")}
                 />
@@ -165,16 +170,17 @@ export default function IllustPostPage() {
               <section>
                 <Mantine.Textarea
                   name="caption"
-                  label="キャプション"
-                  size="lg"
+                  label={t_PostGeneral("caption")}
+                  size="sm"
                   radius="xs"
+                  rows={5}
                   {...form.getInputProps("caption")}
                 />
               </section>
               <section>
                 <Mantine.TagsInput
                   name="tags"
-                  label="タグ"
+                  label={t_PostGeneral("tag")}
                   splitChars={[" ", "|"]}
                   data={Tags.map((tag) => tag.title)}
                   onChange={setTags}
@@ -185,7 +191,7 @@ export default function IllustPostPage() {
                 <div className="md:w-1/3">
                   <Mantine.Select
                     name="gameSystem"
-                    label="システム"
+                    label={t_PostGeneral("gameSystem")}
                     data={GameSystems.map((system) => system.name)}
                     {...form.getInputProps("gameSystem")}
                   />
@@ -193,7 +199,7 @@ export default function IllustPostPage() {
                 <div className="md:w-2/3">
                   <Mantine.Autocomplete
                     name="synalioTitle"
-                    label="シナリオ"
+                    label={t_PostGeneral("synalioTitle")}
                     data={Synalios.map((synalio) => synalio.title)}
                     {...form.getInputProps("synalioTitle")}
                   />
@@ -201,48 +207,45 @@ export default function IllustPostPage() {
               </section>
               <section>
                 <Mantine.Radio.Group
-                  name="PublishRange"
-                  label="公開範囲"
+                  name="publishRange"
+                  label={t_PostGeneral("publishRange")}
                   withAsterisk
                   {...form.getInputProps("publishRange")}
                 >
                   <Mantine.Group>
                     <Mantine.Radio
-                      label="全体公開"
+                      label={t_PostGeneral("allPublish")}
                       value={PublishRange.All}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
-                      label="URLを知ってる人"
+                      label={t_PostGeneral("urlPublish")}
                       value={PublishRange.URL}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
-                      label="フォロワー"
+                      label={t_PostGeneral("followerPublish")}
                       value={PublishRange.Follower}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
-                      label="非公開"
+                      label={t_PostGeneral("private")}
                       value={PublishRange.Private}
                       style={{ cursor: "pointer" }}
                     />
                   </Mantine.Group>
                 </Mantine.Radio.Group>
                 <p className="text-sm my-4">
-                  ※「全体公開」と「URLを知っている人」はログインユーザーでなくても見れます
+                  {t_PostGeneral("publishAttention")}
                 </p>
               </section>
               <section className="my-8">
                 <Mantine.Group className="flex justify-center items-center">
                   <Mantine.Button
                     type="submit"
-                    onClick={() =>
-                      form.setValues({ publishRange: PublishRange.All })
-                    }
                     className="bg-green-300 text-black hover:bg-green-500 hover:text-black"
                   >
-                    投稿
+                    {t_PostGeneral("post")}
                   </Mantine.Button>
                   <Mantine.Button
                     type="submit"
@@ -251,7 +254,7 @@ export default function IllustPostPage() {
                     }
                     className="bg-slate-500 hover:bg-slate-800"
                   >
-                    下書き保存
+                    {t_PostGeneral("draftSave")}
                   </Mantine.Button>
                 </Mantine.Group>
               </section>
@@ -263,8 +266,8 @@ export default function IllustPostPage() {
       <TransitionsModal onClose={handleModalClose}>
         <h3 className="text-xl text-center my-4">
           {form.values.publishRange === PublishRange.Draft
-            ? "下書き保存しました"
-            : "作品を投稿しました"}
+            ? t_PostGeneral("draftSaved")
+            : t_PostGeneral("posted")}
         </h3>
         <Mantine.Group justify="center" gap={8}>
           {form.values.publishRange === PublishRange.Draft ? (
@@ -273,7 +276,7 @@ export default function IllustPostPage() {
                 className="bg-green-300 text-black"
                 onClick={handleModalClose}
               >
-                閉じる
+                {t_PostGeneral("close")}
               </Mantine.Button>
             </>
           ) : (
@@ -282,10 +285,10 @@ export default function IllustPostPage() {
                 className="bg-green-300 text-black"
                 onClick={() => router.push(RouterPath.illust(postId))}
               >
-                作品を見に行く
+                {t_PostGeneral("showPost")}
               </Mantine.Button>
               <Mantine.Button className="bg-black text-white">
-                Xに投稿する
+                {t_PostGeneral("XShare")}
               </Mantine.Button>
             </>
           )}

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -77,13 +77,12 @@ export default function IllustPostPage() {
   };
 
   const handleDrop = (files: File[]) => {
-    files.map((file) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        setPostIllust([...postIllust, reader.result as string]);
-      };
-      reader.readAsDataURL(file);
-    });
+    // TODO : 一枚のみ対応、後々複数枚対応する
+    const reader = new FileReader();
+    reader.onload = () => {
+      setPostIllust([reader.result as string]);
+    };
+    reader.readAsDataURL(files[0]);
   };
 
   const handleModalClose = () => {
@@ -112,7 +111,6 @@ export default function IllustPostPage() {
                 </label>
                 <Dropzone
                   name="postIllust"
-                  /*multiple*/ // TODO : 複数投稿は後にする
                   onDrop={(files) => handleDrop(files)}
                   maxSize={5 * 1024 ** 2}
                   accept={IMAGE_MIME_TYPE}
@@ -126,17 +124,19 @@ export default function IllustPostPage() {
                   {...form.getInputProps("postIllust")}
                 >
                   <Dropzone.Idle>
-                    {postIllust.length > 0 &&
-                      postIllust.map((illust, index) => (
+                    {
+                      postIllust.length > 0 && (
                         <Mantine.Image
-                          key={index}
-                          src={illust}
+                          src={postIllust[0]}
                           h={mobile ? "15rem" : "30rem"}
-                          w="100%"
+                          w="auto"
+                          m="auto"
                           fit="cover"
                           className="opacity-50"
                         />
-                      ))}
+                      )
+                      // ))
+                    }
                     <FaImage
                       className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
                       style={{

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -1,3 +1,231 @@
+"use client";
+
+import * as Mantine from "@mantine/core";
+import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
+import { useForm } from "@mantine/form";
+import { useMediaQuery } from "@mantine/hooks";
+import { useState } from "react";
+import { FaImage } from "rocketicons/fa";
+
+// 仮データをハードコーディング
+const Tags = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  title: `タグ${i}`,
+}));
+
+const GameSystems = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  name: `システム${i}`,
+}));
+
+const Synalios = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  title: `シナリオ${i}`,
+}));
+
+enum PublishRange {
+  hidden = "hidden",
+  All = "All",
+  Draft = "Draft",
+  URL = "URL",
+  Follower = "Follower",
+  Private = "Private",
+}
+
 export default function IllustPostPage() {
-  return <div>イラスト投稿ページ</div>;
+  const theme = Mantine.useMantineTheme();
+  const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
+  const [postIllust, setPostIllust] = useState<string[]>([] as string[]);
+  const [tags, setTags] = useState<string[]>([] as string[]);
+  const [publishRange, setPublishRange] = useState<string>(PublishRange.hidden);
+
+  const form = useForm({
+    initialValues: {
+      postIllust: [],
+      title: "",
+      caption: "",
+      tags: [],
+      gameSystem: Number,
+      synalioTitle: String,
+      publishRange: Number,
+    },
+    validate: {
+      postIllust: (value) => {
+        if (!value) {
+          return "イラストをアップロードしてください";
+        }
+      },
+      title: (value) => {
+        if (!value) {
+          return "タイトルを入力してください";
+        }
+      },
+      publishRange: (value) => {
+        if (!value) {
+          return "公開範囲を選択してください";
+        }
+      },
+    },
+  });
+
+  const handleDrop = (files: File[]) => {
+    files.map((file) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setPostIllust([...postIllust, reader.result as string]);
+      };
+      reader.readAsDataURL(file);
+    });
+  };
+
+  return (
+    <article className="mt-8 mb-12">
+      <Mantine.Container size={"sm"}>
+        <Mantine.Box className="bg-white p-4 px-8 rounded">
+          <h1 className="text-center font-semibold my-4">イラスト投稿</h1>
+          <form className="flex flex-col gap-5">
+            <section>
+              <label htmlFor="postIllust">イラストアップロード</label>
+              <Dropzone
+                name="postIllust"
+                /*multiple*/ // TODO : 複数投稿は後にする
+                onDrop={(files) => handleDrop(files)}
+                maxSize={5 * 1024 ** 2}
+                accept={IMAGE_MIME_TYPE}
+                style={{
+                  height: mobile ? "8rem" : "15rem",
+                  width: "auto",
+                  margin: "0 auto",
+                  position: "relative",
+                  cursor: "pointer",
+                }}
+              >
+                <Dropzone.Idle>
+                  {postIllust.length > 0 &&
+                    postIllust.map((illust, index) => (
+                      <Mantine.Image
+                        key={index}
+                        src={illust}
+                        h={mobile ? "8rem" : "15rem"}
+                        w="100%"
+                        fit="cover"
+                        className="opacity-50"
+                      />
+                    ))}
+                  <FaImage
+                    className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                    style={{
+                      width: "3rem",
+                      height: "3rem",
+                    }}
+                  />
+                </Dropzone.Idle>
+              </Dropzone>
+            </section>
+            <section>
+              <Mantine.TextInput
+                required
+                withAsterisk
+                label="タイトル"
+                name="title"
+                {...form.getInputProps("title")}
+              />
+              {form.errors.title && (
+                <span className="text-red-400 text-xs ml-4">
+                  {form.errors.title}
+                </span>
+              )}
+            </section>
+            <section>
+              <Mantine.Textarea
+                name="caption"
+                label="キャプション"
+                size="lg"
+                radius="xs"
+                {...form.getInputProps("caption")}
+              />
+            </section>
+            <section>
+              <Mantine.TagsInput
+                name="tags"
+                label="タグ"
+                splitChars={[" ", "|"]}
+                data={Tags.map((tag) => tag.title)}
+                onChange={setTags}
+                value={tags}
+              />
+            </section>
+            <section className="flex gap-5 flex-col md:flex-row md:items-center md:gap-2 w-full ">
+              <div className="md:w-1/3">
+                <Mantine.Select
+                  name="gameSystem"
+                  label="システム"
+                  data={GameSystems.map((system) => system.name)}
+                  {...form.getInputProps("gameSystem")}
+                />
+              </div>
+              <div className="md:w-2/3">
+                <Mantine.Autocomplete
+                  name="synalioTitle"
+                  label="シナリオ"
+                  data={Synalios.map((synalio) => synalio.title)}
+                  {...form.getInputProps("synalioTitle")}
+                />
+              </div>
+            </section>
+            <section>
+              <Mantine.Radio.Group
+                name="PublishRange"
+                label="公開範囲"
+                withAsterisk
+                required
+                value={publishRange}
+                onChange={setPublishRange}
+              >
+                <Mantine.Group>
+                  <Mantine.Radio
+                    label="全体公開"
+                    value={PublishRange.All}
+                    style={{ cursor: "pointer" }}
+                  />
+                  <Mantine.Radio
+                    label="URLを知ってる人"
+                    value={PublishRange.URL}
+                    style={{ cursor: "pointer" }}
+                  />
+                  <Mantine.Radio
+                    label="フォロワー"
+                    value={PublishRange.Follower}
+                    style={{ cursor: "pointer" }}
+                  />
+                  <Mantine.Radio
+                    label="非公開"
+                    value={PublishRange.Private}
+                    style={{ cursor: "pointer" }}
+                  />
+                </Mantine.Group>
+              </Mantine.Radio.Group>
+            </section>
+            <section className="my-8">
+              <Mantine.Group className="flex justify-center items-center">
+                <Mantine.Button
+                  type="submit"
+                  className="bg-green-300 text-black"
+                >
+                  投稿
+                </Mantine.Button>
+                <Mantine.Button
+                  type="submit"
+                  value={PublishRange.Draft}
+                  className="bg-slate-500"
+                >
+                  下書き保存
+                </Mantine.Button>
+              </Mantine.Group>
+            </section>
+          </form>
+        </Mantine.Box>
+      </Mantine.Container>
+    </article>
+  );
 }

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -42,6 +42,7 @@ export default function IllustPostPage() {
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
   const [postIllust, setPostIllust] = useState<string[]>([] as string[]);
   const [tags, setTags] = useState<string[]>([] as string[]);
+  const [postId, setPostId] = useState<number>(0);
   const setOpenModal = useSetRecoilState(modalOpenState);
   const router = useRouter();
   const user = useRecoilValue(userState);
@@ -74,6 +75,8 @@ export default function IllustPostPage() {
   const handleSubmit = () => {
     // TODO : 投稿処理
 
+    setPostId(1);
+
     // 投稿・下書きしたらモーダル表示
     setOpenModal(true);
   };
@@ -89,11 +92,10 @@ export default function IllustPostPage() {
   };
 
   const handleModalClose = () => {
-    if (form.values.publishRange === PublishRange.Draft) {
-      setOpenModal(false);
-    } else {
+    if (form.values.publishRange !== PublishRange.Draft) {
       router.push(RouterPath.users(user.id));
     }
+    setOpenModal(false);
   };
 
   return (
@@ -276,7 +278,10 @@ export default function IllustPostPage() {
             </>
           ) : (
             <>
-              <Mantine.Button className="bg-green-300 text-black">
+              <Mantine.Button
+                className="bg-green-300 text-black"
+                onClick={() => router.push(RouterPath.illust(postId))}
+              >
                 作品を見に行く
               </Mantine.Button>
               <Mantine.Button className="bg-black text-white">

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { TransitionsModal } from "@/components/ui";
+import { useRouter } from "@/lib";
+import { modalOpenState, userState } from "@/recoilState";
+import { RouterPath } from "@/settings";
 import * as Mantine from "@mantine/core";
 import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
 import { useMediaQuery } from "@mantine/hooks";
 import { useState } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { FaImage } from "rocketicons/fa";
 
 // 仮データをハードコーディング
@@ -37,21 +42,19 @@ export default function IllustPostPage() {
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
   const [postIllust, setPostIllust] = useState<string[]>([] as string[]);
   const [tags, setTags] = useState<string[]>([] as string[]);
-  const [publishRange, setPublishRange] = useState<string>(PublishRange.hidden);
+  const setOpenModal = useSetRecoilState(modalOpenState);
+  const router = useRouter();
+  const user = useRecoilValue(userState);
 
   const form = useForm({
     initialValues: {
-      postIllust: [],
+      postIllust: postIllust,
       title: "",
-      caption: "",
-      tags: [],
-      gameSystem: Number,
-      synalioTitle: String,
-      publishRange: Number,
+      publishRange: PublishRange.hidden,
     },
     validate: {
-      postIllust: (value) => {
-        if (!value) {
+      postIllust: () => {
+        if (postIllust.length === 0) {
           return "イラストをアップロードしてください";
         }
       },
@@ -61,12 +64,19 @@ export default function IllustPostPage() {
         }
       },
       publishRange: (value) => {
-        if (!value) {
+        if (!value || value === PublishRange.hidden) {
           return "公開範囲を選択してください";
         }
       },
     },
   });
+
+  const handleSubmit = () => {
+    // TODO : 投稿処理
+
+    // 投稿・下書きしたらモーダル表示
+    setOpenModal(true);
+  };
 
   const handleDrop = (files: File[]) => {
     files.map((file) => {
@@ -78,154 +88,201 @@ export default function IllustPostPage() {
     });
   };
 
+  const handleModalClose = () => {
+    if (form.values.publishRange === PublishRange.Draft) {
+      setOpenModal(false);
+    } else {
+      router.push(RouterPath.users(user.id));
+    }
+  };
+
   return (
-    <article className="mt-8 mb-12">
-      <Mantine.Container size={"sm"}>
-        <Mantine.Box className="bg-white p-4 px-8 rounded">
-          <h1 className="text-center font-semibold my-4">イラスト投稿</h1>
-          <form className="flex flex-col gap-5">
-            <section>
-              <label htmlFor="postIllust">イラストアップロード</label>
-              <Dropzone
-                name="postIllust"
-                /*multiple*/ // TODO : 複数投稿は後にする
-                onDrop={(files) => handleDrop(files)}
-                maxSize={5 * 1024 ** 2}
-                accept={IMAGE_MIME_TYPE}
-                style={{
-                  height: mobile ? "8rem" : "15rem",
-                  width: "auto",
-                  margin: "0 auto",
-                  position: "relative",
-                  cursor: "pointer",
-                }}
-              >
-                <Dropzone.Idle>
-                  {postIllust.length > 0 &&
-                    postIllust.map((illust, index) => (
-                      <Mantine.Image
-                        key={index}
-                        src={illust}
-                        h={mobile ? "8rem" : "15rem"}
-                        w="100%"
-                        fit="cover"
-                        className="opacity-50"
-                      />
-                    ))}
-                  <FaImage
-                    className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
-                    style={{
-                      width: "3rem",
-                      height: "3rem",
-                    }}
-                  />
-                </Dropzone.Idle>
-              </Dropzone>
-            </section>
-            <section>
-              <Mantine.TextInput
-                required
-                withAsterisk
-                label="タイトル"
-                name="title"
-                {...form.getInputProps("title")}
-              />
-              {form.errors.title && (
-                <span className="text-red-400 text-xs ml-4">
-                  {form.errors.title}
-                </span>
-              )}
-            </section>
-            <section>
-              <Mantine.Textarea
-                name="caption"
-                label="キャプション"
-                size="lg"
-                radius="xs"
-                {...form.getInputProps("caption")}
-              />
-            </section>
-            <section>
-              <Mantine.TagsInput
-                name="tags"
-                label="タグ"
-                splitChars={[" ", "|"]}
-                data={Tags.map((tag) => tag.title)}
-                onChange={setTags}
-                value={tags}
-              />
-            </section>
-            <section className="flex gap-5 flex-col md:flex-row md:items-center md:gap-2 w-full ">
-              <div className="md:w-1/3">
-                <Mantine.Select
-                  name="gameSystem"
-                  label="システム"
-                  data={GameSystems.map((system) => system.name)}
-                  {...form.getInputProps("gameSystem")}
+    <>
+      <article className="mt-8 mb-12">
+        <Mantine.Container size={"sm"}>
+          <Mantine.Box className="bg-white p-4 px-8 rounded">
+            <h1 className="text-center font-semibold my-4">イラスト投稿</h1>
+            <form
+              className="flex flex-col gap-5"
+              onSubmit={form.onSubmit(handleSubmit)}
+            >
+              <section>
+                <label htmlFor="postIllust">
+                  イラストアップロード<span className="text-red-600">*</span>
+                </label>
+                <Dropzone
+                  name="postIllust"
+                  /*multiple*/ // TODO : 複数投稿は後にする
+                  onDrop={(files) => handleDrop(files)}
+                  maxSize={5 * 1024 ** 2}
+                  accept={IMAGE_MIME_TYPE}
+                  style={{
+                    height: mobile ? "15rem" : "30rem",
+                    width: "auto",
+                    margin: "0 auto",
+                    position: "relative",
+                    cursor: "pointer",
+                  }}
+                  {...form.getInputProps("postIllust")}
+                >
+                  <Dropzone.Idle>
+                    {postIllust.length > 0 &&
+                      postIllust.map((illust, index) => (
+                        <Mantine.Image
+                          key={index}
+                          src={illust}
+                          h={mobile ? "15rem" : "30rem"}
+                          w="100%"
+                          fit="cover"
+                          className="opacity-50"
+                        />
+                      ))}
+                    <FaImage
+                      className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                      style={{
+                        width: "3rem",
+                        height: "3rem",
+                      }}
+                    />
+                  </Dropzone.Idle>
+                </Dropzone>
+                {form.errors.postIllust && (
+                  <p className="text-sm text-red-500">
+                    {form.errors.postIllust}
+                  </p>
+                )}
+              </section>
+              <section>
+                <Mantine.TextInput
+                  withAsterisk
+                  label="タイトル"
+                  name="title"
+                  {...form.getInputProps("title")}
                 />
-              </div>
-              <div className="md:w-2/3">
-                <Mantine.Autocomplete
-                  name="synalioTitle"
-                  label="シナリオ"
-                  data={Synalios.map((synalio) => synalio.title)}
-                  {...form.getInputProps("synalioTitle")}
+              </section>
+              <section>
+                <Mantine.Textarea
+                  name="caption"
+                  label="キャプション"
+                  size="lg"
+                  radius="xs"
+                  {...form.getInputProps("caption")}
                 />
-              </div>
-            </section>
-            <section>
-              <Mantine.Radio.Group
-                name="PublishRange"
-                label="公開範囲"
-                withAsterisk
-                required
-                value={publishRange}
-                onChange={setPublishRange}
-              >
-                <Mantine.Group>
-                  <Mantine.Radio
-                    label="全体公開"
-                    value={PublishRange.All}
-                    style={{ cursor: "pointer" }}
+              </section>
+              <section>
+                <Mantine.TagsInput
+                  name="tags"
+                  label="タグ"
+                  splitChars={[" ", "|"]}
+                  data={Tags.map((tag) => tag.title)}
+                  onChange={setTags}
+                  value={tags}
+                />
+              </section>
+              <section className="flex gap-5 flex-col md:flex-row md:items-center md:gap-2 w-full ">
+                <div className="md:w-1/3">
+                  <Mantine.Select
+                    name="gameSystem"
+                    label="システム"
+                    data={GameSystems.map((system) => system.name)}
+                    {...form.getInputProps("gameSystem")}
                   />
-                  <Mantine.Radio
-                    label="URLを知ってる人"
-                    value={PublishRange.URL}
-                    style={{ cursor: "pointer" }}
+                </div>
+                <div className="md:w-2/3">
+                  <Mantine.Autocomplete
+                    name="synalioTitle"
+                    label="シナリオ"
+                    data={Synalios.map((synalio) => synalio.title)}
+                    {...form.getInputProps("synalioTitle")}
                   />
-                  <Mantine.Radio
-                    label="フォロワー"
-                    value={PublishRange.Follower}
-                    style={{ cursor: "pointer" }}
-                  />
-                  <Mantine.Radio
-                    label="非公開"
-                    value={PublishRange.Private}
-                    style={{ cursor: "pointer" }}
-                  />
+                </div>
+              </section>
+              <section>
+                <Mantine.Radio.Group
+                  name="PublishRange"
+                  label="公開範囲"
+                  withAsterisk
+                  {...form.getInputProps("publishRange")}
+                >
+                  <Mantine.Group>
+                    <Mantine.Radio
+                      label="全体公開"
+                      value={PublishRange.All}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label="URLを知ってる人"
+                      value={PublishRange.URL}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label="フォロワー"
+                      value={PublishRange.Follower}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label="非公開"
+                      value={PublishRange.Private}
+                      style={{ cursor: "pointer" }}
+                    />
+                  </Mantine.Group>
+                </Mantine.Radio.Group>
+              </section>
+              <section className="my-8">
+                <Mantine.Group className="flex justify-center items-center">
+                  <Mantine.Button
+                    type="submit"
+                    onClick={() =>
+                      form.setValues({ publishRange: PublishRange.All })
+                    }
+                    className="bg-green-300 text-black hover:bg-green-500 hover:text-black"
+                  >
+                    投稿
+                  </Mantine.Button>
+                  <Mantine.Button
+                    type="submit"
+                    onClick={() =>
+                      form.setValues({ publishRange: PublishRange.Draft })
+                    }
+                    className="bg-slate-500 hover:bg-slate-800"
+                  >
+                    下書き保存
+                  </Mantine.Button>
                 </Mantine.Group>
-              </Mantine.Radio.Group>
-            </section>
-            <section className="my-8">
-              <Mantine.Group className="flex justify-center items-center">
-                <Mantine.Button
-                  type="submit"
-                  className="bg-green-300 text-black"
-                >
-                  投稿
-                </Mantine.Button>
-                <Mantine.Button
-                  type="submit"
-                  value={PublishRange.Draft}
-                  className="bg-slate-500"
-                >
-                  下書き保存
-                </Mantine.Button>
-              </Mantine.Group>
-            </section>
-          </form>
-        </Mantine.Box>
-      </Mantine.Container>
-    </article>
+              </section>
+            </form>
+          </Mantine.Box>
+        </Mantine.Container>
+      </article>
+
+      <TransitionsModal onClose={handleModalClose}>
+        <h3 className="text-xl text-center my-4">
+          {form.values.publishRange === PublishRange.Draft
+            ? "下書き保存しました"
+            : "作品を投稿しました"}
+        </h3>
+        <Mantine.Group justify="center" gap={8}>
+          {form.values.publishRange === PublishRange.Draft ? (
+            <>
+              <Mantine.Button
+                className="bg-green-300 text-black"
+                onClick={handleModalClose}
+              >
+                閉じる
+              </Mantine.Button>
+            </>
+          ) : (
+            <>
+              <Mantine.Button className="bg-green-300 text-black">
+                作品を見に行く
+              </Mantine.Button>
+              <Mantine.Button className="bg-black text-white">
+                Xに投稿する
+              </Mantine.Button>
+            </>
+          )}
+        </Mantine.Group>
+      </TransitionsModal>
+    </>
   );
 }

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -227,6 +227,9 @@ export default function IllustPostPage() {
                     />
                   </Mantine.Group>
                 </Mantine.Radio.Group>
+                <p className="text-sm my-4">
+                  ※「全体公開」と「URLを知っている人」はログインユーザーでなくても見れます
+                </p>
               </section>
               <section className="my-8">
                 <Mantine.Group className="flex justify-center items-center">

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -4,6 +4,7 @@ import { TransitionsModal } from "@/components/ui";
 import { useRouter } from "@/lib";
 import { modalOpenState, userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
+import { PublicState } from "@/types";
 import * as Mantine from "@mantine/core";
 import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
@@ -29,14 +30,6 @@ const Synalios = Array.from({ length: 50 }).map((_, i) => ({
   title: `シナリオ${i}`,
 }));
 
-enum PublishRange {
-  All = "All",
-  Draft = "Draft",
-  URL = "URL",
-  Follower = "Follower",
-  Private = "Private",
-}
-
 export default function IllustPostPage() {
   const theme = Mantine.useMantineTheme();
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
@@ -53,7 +46,7 @@ export default function IllustPostPage() {
     initialValues: {
       postIllust: postIllust,
       title: "",
-      publishRange: "" as PublishRange,
+      publishRange: "" as PublicState,
     },
     validate: {
       postIllust: () => {
@@ -94,7 +87,7 @@ export default function IllustPostPage() {
   };
 
   const handleModalClose = () => {
-    if (form.values.publishRange !== PublishRange.Draft) {
+    if (form.values.publishRange !== PublicState.Draft) {
       router.push(RouterPath.users(user.id));
     }
     setOpenModal(false);
@@ -215,22 +208,22 @@ export default function IllustPostPage() {
                   <Mantine.Group>
                     <Mantine.Radio
                       label={t_PostGeneral("allPublish")}
-                      value={PublishRange.All}
+                      value={PublicState.All}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("urlPublish")}
-                      value={PublishRange.URL}
+                      value={PublicState.URL}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("followerPublish")}
-                      value={PublishRange.Follower}
+                      value={PublicState.Follower}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("private")}
-                      value={PublishRange.Private}
+                      value={PublicState.Private}
                       style={{ cursor: "pointer" }}
                     />
                   </Mantine.Group>
@@ -250,7 +243,7 @@ export default function IllustPostPage() {
                   <Mantine.Button
                     type="submit"
                     onClick={() =>
-                      form.setValues({ publishRange: PublishRange.Draft })
+                      form.setValues({ publishRange: PublicState.Draft })
                     }
                     className="bg-slate-500 hover:bg-slate-800"
                   >
@@ -265,12 +258,12 @@ export default function IllustPostPage() {
 
       <TransitionsModal onClose={handleModalClose}>
         <h3 className="text-xl text-center my-4">
-          {form.values.publishRange === PublishRange.Draft
+          {form.values.publishRange === PublicState.Draft
             ? t_PostGeneral("draftSaved")
             : t_PostGeneral("posted")}
         </h3>
         <Mantine.Group justify="center" gap={8}>
-          {form.values.publishRange === PublishRange.Draft ? (
+          {form.values.publishRange === PublicState.Draft ? (
             <>
               <Mantine.Button
                 className="bg-green-300 text-black"

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/lib";
+import { RouterPath } from "@/settings";
 import { IndexIllustData } from "@/types";
 import { Image } from "@mantine/core";
 import dynamic from "next/dynamic";
@@ -19,7 +20,7 @@ export default function Illust({
 }) {
   return (
     <section>
-      <Link href={`/illusts/${illust.id}`} className="relative z-0">
+      <Link href={RouterPath.illust(illust.id)} className="relative z-0">
         <Image
           src={illust.image}
           loading="lazy"

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -166,7 +166,6 @@ export default function UserEdit({
               <MantineDropzone.Dropzone
                 name="headerImage"
                 onDrop={(files) => handleDrop(files, setHeaderImageBlob)}
-                onReject={() => console.log("reject")}
                 maxSize={5 * 1024 ** 2}
                 accept={MantineDropzone.IMAGE_MIME_TYPE}
                 style={{
@@ -201,7 +200,6 @@ export default function UserEdit({
                 <MantineDropzone.Dropzone
                   name="avatarImage"
                   onDrop={(files) => handleDrop(files, setAvatarBlob)}
-                  onReject={() => setAvatarBlob("")}
                   maxSize={5 * 1024 ** 2}
                   accept={MantineDropzone.IMAGE_MIME_TYPE}
                   style={{

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -42,7 +42,7 @@ export default function Headers() {
   };
 
   const handlePost = () => {
-    router.push("/illusts/post");
+    router.push(RouterPath.illustPost);
   };
 
   return (
@@ -61,7 +61,7 @@ export default function Headers() {
           </Link>
         </h1>
         <div className="md:flex md:items-center md:justify-center md:gap-8">
-          <div className="hidden  md:flex md:flex-col md:justify-end md:items-start">
+          <div className="md:flex md:flex-col md:justify-end md:items-start">
             <form
               className="md:flex md:justify-center md:items-center gap-2"
               onSubmit={handleSearch}
@@ -92,7 +92,7 @@ export default function Headers() {
               <Mantine.Button
                 variant="contained"
                 onClick={handlePost}
-                className="hidden md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
+                className="md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
               >
                 {t_Header("postButton")}
               </Mantine.Button>

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -23,7 +23,7 @@ export function IconButtonList({
           <BookmarkButton state={buttonState.bookmark} />
         </li>
         {/* 公開範囲が全体のときのみシェア可能 */}
-        {publicState.valueOf() === PublicState.PUBLIC && (
+        {publicState.valueOf() === PublicState.All && (
           <li className="w-1/3 h-full text-center">
             <ShareButton />
           </li>
@@ -55,7 +55,7 @@ export function FixedIconButtonList({
           <BookmarkButton state={buttonState.bookmark} />
         </li>
         {/* 公開範囲が全体のときのみシェア可能 */}
-        {publicState.valueOf() === PublicState.PUBLIC && (
+        {publicState.valueOf() === PublicState.Private && (
           <li className="w-1/3 h-full text-center">
             <ShareButton />
           </li>

--- a/front/src/components/ui/modal/modal.tsx
+++ b/front/src/components/ui/modal/modal.tsx
@@ -6,15 +6,22 @@ import { Modal } from "@mantine/core";
 
 export default function TransitionsModal({
   children,
+  onClose,
 }: {
   children: React.ReactNode;
+  onClose?: () => void;
 }) {
   const [open, setOpen] = useRecoilState(ModalState.modalOpenState);
   const title = useRecoilValue(ModalState.modalTitleState);
 
+  const handleClose = () => {
+    setOpen(false);
+    onClose && onClose();
+  };
+
   return (
     <>
-      <Modal opened={open} onClose={() => setOpen(false)} title={title}>
+      <Modal opened={open} onClose={handleClose} title={title}>
         {children}
       </Modal>
     </>

--- a/front/src/components/ui/modal/searchModal.tsx
+++ b/front/src/components/ui/modal/searchModal.tsx
@@ -28,21 +28,6 @@ enum SearchType {
   OR = "OR",
 }
 
-const style = {
-  position: "absolute" as "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  bgcolor: "background.paper",
-  width: "100%",
-  maxWidth: "600px",
-  boxShadow: 24,
-  p: 4,
-  borderRadius: 1,
-  display: "flex",
-  flexDirection: "column",
-};
-
 export default function SearchModal() {
   const t_Search = useTranslations("Search");
   const t_SearchOption = useTranslations("SearchOption");

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -9,6 +9,7 @@ export const RouterPath = {
   illustIndex: "/",
   illust: (id: number) => `/illusts/${id}`,
   illustSearch: (searchWord: string) => `/illusts?search=${searchWord}`,
+  illustPost: "/illusts/post",
   users: (id: number) => `/users/${id}`,
   account: "/account",
   bookmark: (id: number) => `/users/${id}?bookmark=true`,

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -7,6 +7,7 @@ export const RouterPath = {
   signUp: "/signup",
   login: "/login",
   illustIndex: "/",
+  illust: (id: number) => `/illusts/${id}`,
   illustSearch: (searchWord: string) => `/illusts?search=${searchWord}`,
   users: (id: number) => `/users/${id}`,
   account: "/account",

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -23,13 +23,6 @@ export interface IUser {
   follower_count: number;
 }
 
-export enum PublicState {
-  DRAFT = 0, // 下書き
-  PRIVATE = 1, // 非公開
-  PUBLIC = 2, // 全体公開
-  ONLY_URL = 3, // URLを知ってる人のみ
-}
-
 export interface NoticeState {
   favorite: boolean;
   bookmark: boolean;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -47,3 +47,11 @@ export interface UserPageEdit {
   };
   profile: string;
 }
+
+export enum PublicState {
+  All = "All",
+  Draft = "Draft",
+  URL = "URL",
+  Follower = "Follower",
+  Private = "Private",
+}


### PR DESCRIPTION
# 概要
イラスト投稿ページのガワを作成しました。

## 実装項目
- [x] イラストアップロードができること
- [x] アップロードしたイラストは即座にプレビューが表示されること
- [x] タイトルのラベルと入力フォームがあること
- [x] キャプションのラベルとテキストエリアがあること
- [x] タグのラベルとタグの入力フォームがあること
- [x] タグはオートコンプリートがあること
- [x] システムラベルとプルダウンがあること
- [x] シナリオ名のラベルと入力フォームがあること
- [x] シナリオ名はオートコンプリートがあること
- [x] 公開範囲のラベルとラジオボタンがあること
   - [x] 全体公開
   - [x] URLを知っている人
   - [x] フォロワー
   - [x] 非公開
   - [x] 「全体公開」「URLを知っている人」は未ログインでも見れる文言があること
- [x] 投稿ボタンがあること
- [x] 下書きボタンがあること
- [x] 投稿ボタンを押すとモーダルが表示されること
   - [x] 作品を見に行くリンクがあること
   - [x] Xシェアボタンがあること
   - [x] 閉じるボタンがあり、閉じるとモーダルが閉じること
- [x] 下書きボタンを押すとモーダルが表示されること
   - [x] プレビューを見るリンクがあること
   - [x] 閉じるボタンがあり、閉じるとモーダルが閉じること

## 追加項目
- [x] 投稿した場合、編集できないようモーダルを閉じたらユーザーページに飛ぶようにしました

## 挙動
| 投稿PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/05d03a4d74d0480fd13a8d021778c144.gif" width="470px" /> | <img src="https://i.gyazo.com/cd1d688ba6c28ed783645aec6eaa29a1.gif" width="200px" /> |

| バリデーションPC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/ca2ed130c1dbaa9664295ece065c8a87.gif" width="470px" /> | <img src="https://i.gyazo.com/9181af4a4bd1b8aa2258d9206936632d.gif" width="200px" /> |

| 下書き保存PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/0b9f28aa202a41f3d0029c02e94340e1.gif" width="470px" /> | <img src="https://i.gyazo.com/206a593db91d024ef77d67db8eb0d6f6.gif" width="200px" /> |