### PR TITLE
【feature】イラスト編集ページのガワ作成 close #65

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -114,6 +114,12 @@
     "upload": "イラストアップロード",
     "uploadValid": "イラストをアップロードしてください"
   },
+  "PostIllustEdit": {
+    "title": "イラスト編集",
+    "illustPostAttention": "一度公開したイラストは変更できません",
+    "upload": "イラストアップロード",
+    "uploadValid": "イラストをアップロードしてください"
+  },
   "PostGeneral": {
     "title": "タイトル",
     "caption": "キャプション",
@@ -134,6 +140,8 @@
     "showPost": "作品を見に行く",
     "XShare": "Xに投稿する",
     "titleValid": "タイトルを入力してください",
-    "publishValid": "公開範囲を選択してください"
+    "publishValid": "公開範囲を選択してください",
+    "overwrite": "上書き保存",
+    "delete": "作品を削除する"
   }
 }

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -59,7 +59,8 @@
     "oldPosts": "投稿順",
     "sortBy": "表示順",
     "edit": "編集",
-    "save": "保存"
+    "save": "保存",
+    "back": "戻る"
   },
   "Search": {
     "searchResult": "検索結果",
@@ -143,5 +144,12 @@
     "publishValid": "公開範囲を選択してください",
     "overwrite": "上書き保存",
     "delete": "作品を削除する"
+  },
+  "EditGeneral": {
+    "deleteButton": "削除",
+    "deleteCheckLabel": "作品を削除する",
+    "checkDeleteValid": "削除するにはチェックを入れてください",
+    "deleteModalTItle": "本当に削除しますか？",
+    "deleteModalAttention": "※作品を削除すると元に戻すことはできません"
   }
 }

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -1,3 +1,389 @@
-export default function IllustEditPage() {
-  return <div>イラスト編集ページ</div>;
+"use client";
+
+import { TransitionsModal } from "@/components/ui";
+import { useRouter } from "@/lib";
+import { modalOpenState, userState } from "@/recoilState";
+import { RouterPath } from "@/settings";
+import { PublicState } from "@/types";
+import * as Mantine from "@mantine/core";
+import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
+import { useForm } from "@mantine/form";
+import { useMediaQuery } from "@mantine/hooks";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { FaImage } from "rocketicons/fa";
+
+// 仮データをハードコーディング
+const Tags = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  title: `タグ${i}`,
+}));
+
+const GameSystems = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  name: `システム${i}`,
+}));
+
+const Synalios = Array.from({ length: 50 }).map((_, i) => ({
+  id: i,
+  title: `シナリオ${i}`,
+}));
+
+const Illust = {
+  id: 1,
+  image: "https://source.unsplash.com/random",
+  title: "タイトル",
+  caption: "キャプション",
+  gameSystem: "システム1",
+  synalioTitle: "シナリオ名",
+  publishRange: PublicState.All,
+  Tags: ["タグ1", "タグ2"],
+};
+
+export default function IllustEditPage({ params }: { params: { id: string } }) {
+  const theme = Mantine.useMantineTheme();
+  const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
+  const [postIllust, setPostIllust] = useState<string[]>([Illust.image]);
+  const [tags, setTags] = useState<string[]>(Illust.Tags);
+  const setOpenModal = useSetRecoilState(modalOpenState);
+  const router = useRouter();
+  const user = useRecoilValue(userState);
+  const t_PostIllustEdit = useTranslations("PostIllustEdit");
+  const t_PostGeneral = useTranslations("PostGeneral");
+  const [isDelete, setIsDelete] = useState<boolean>(false);
+  const [isDeleteConfirmation, setIsDeleteConfirmation] =
+    useState<boolean>(false);
+  const [deleteConfirmationError, setDeleteConfirmationError] =
+    useState<string>("");
+
+  const form = useForm({
+    initialValues: {
+      postIllust: postIllust,
+      title: Illust.title,
+      publishRange: Illust.publishRange,
+    },
+    validate: {
+      postIllust: () => {
+        if (postIllust.length === 0) {
+          return t_PostIllustEdit("uploadValid");
+        }
+      },
+      title: (value) => {
+        if (!value) {
+          return t_PostGeneral("titleValid");
+        }
+      },
+      publishRange: (value) => {
+        if (!value) {
+          return t_PostGeneral("publishValid");
+        }
+      },
+    },
+  });
+
+  const handleSubmit = () => {
+    // 投稿・下書きしたらモーダル表示
+    setOpenModal(true);
+  };
+
+  const handleDelete = () => {
+    setOpenModal(true);
+    setIsDelete(true);
+  };
+
+  const handleDeleteSubmit = () => {
+    if (!isDeleteConfirmation) {
+      setDeleteConfirmationError("削除するにはチェックを入れてください");
+      return;
+    }
+  };
+
+  const handleDrop = (files: File[]) => {
+    // TODO : 一枚のみ対応、後々複数枚対応する
+    const reader = new FileReader();
+    reader.onload = () => {
+      setPostIllust([reader.result as string]);
+    };
+    reader.readAsDataURL(files[0]);
+  };
+
+  const handleModalClose = () => {
+    setIsDelete(false);
+    setIsDeleteConfirmation(false);
+    setDeleteConfirmationError("");
+    if (form.values.publishRange !== PublicState.Draft && !isDelete) {
+      router.push(RouterPath.users(user.id));
+    }
+    setOpenModal(false);
+  };
+
+  return (
+    <>
+      <article className="mt-8 mb-12">
+        <Mantine.Container size={"sm"}>
+          <Mantine.Box className="bg-white p-4 px-8 rounded">
+            <h1 className="text-center font-semibold my-4">
+              {t_PostIllustEdit("title")}
+            </h1>
+            <form
+              className="flex flex-col gap-5"
+              onSubmit={form.onSubmit(handleSubmit)}
+            >
+              <section>
+                {Illust.publishRange === PublicState.Draft ? (
+                  <>
+                    <label htmlFor="postIllust">
+                      {t_PostIllustEdit("upload")}
+                      <span className="text-red-600">*</span>
+                    </label>
+                    <Dropzone
+                      name="postIllust"
+                      onDrop={(files) => handleDrop(files)}
+                      maxSize={5 * 1024 ** 2}
+                      accept={IMAGE_MIME_TYPE}
+                      style={{
+                        height: mobile ? "15rem" : "30rem",
+                        width: "auto",
+                        margin: "0 auto",
+                        position: "relative",
+                        cursor: "pointer",
+                      }}
+                      {...form.getInputProps("postIllust")}
+                    >
+                      <Dropzone.Idle>
+                        {postIllust.length > 0 && (
+                          <Mantine.Image
+                            src={postIllust[0]}
+                            h={mobile ? "15rem" : "30rem"}
+                            w="auto"
+                            m="auto"
+                            fit="cover"
+                            className="opacity-50"
+                          />
+                        )}
+                        <FaImage
+                          className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                          style={{
+                            width: "3rem",
+                            height: "3rem",
+                          }}
+                        />
+                      </Dropzone.Idle>
+                    </Dropzone>
+                    {form.errors.postIllust && (
+                      <p className="text-sm text-red-500">
+                        {form.errors.postIllust}
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {postIllust.length > 0 && (
+                      <Mantine.Image
+                        src={postIllust[0]}
+                        h={mobile ? "15rem" : "30rem"}
+                        w="auto"
+                        m="auto"
+                        fit="cover"
+                      />
+                    )}
+                    <p className="text-center text-sm">
+                      ※{t_PostIllustEdit("illustPostAttention")}
+                    </p>
+                  </>
+                )}
+              </section>
+              <section>
+                <Mantine.TextInput
+                  withAsterisk
+                  label={t_PostGeneral("title")}
+                  name="title"
+                  {...form.getInputProps("title")}
+                />
+              </section>
+              <section>
+                <Mantine.Textarea
+                  name="caption"
+                  label={t_PostGeneral("caption")}
+                  size="sm"
+                  radius="xs"
+                  rows={5}
+                  {...form.getInputProps("caption")}
+                />
+              </section>
+              <section>
+                <Mantine.TagsInput
+                  name="tags"
+                  label={t_PostGeneral("tag")}
+                  splitChars={[" ", "|"]}
+                  data={Tags.map((tag) => tag.title)}
+                  onChange={setTags}
+                  value={tags}
+                />
+              </section>
+              <section className="flex gap-5 flex-col md:flex-row md:items-center md:gap-2 w-full ">
+                <div className="md:w-1/3">
+                  <Mantine.Select
+                    name="gameSystem"
+                    label={t_PostGeneral("gameSystem")}
+                    data={GameSystems.map((system) => system.name)}
+                    {...form.getInputProps("gameSystem")}
+                  />
+                </div>
+                <div className="md:w-2/3">
+                  <Mantine.Autocomplete
+                    name="synalioTitle"
+                    label={t_PostGeneral("synalioTitle")}
+                    data={Synalios.map((synalio) => synalio.title)}
+                    {...form.getInputProps("synalioTitle")}
+                  />
+                </div>
+              </section>
+              <section>
+                <Mantine.Radio.Group
+                  name="publishRange"
+                  label={t_PostGeneral("publishRange")}
+                  withAsterisk
+                  {...form.getInputProps("publishRange")}
+                >
+                  <Mantine.Group>
+                    <Mantine.Radio
+                      label={t_PostGeneral("allPublish")}
+                      value={PublicState.All}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label={t_PostGeneral("urlPublish")}
+                      value={PublicState.URL}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label={t_PostGeneral("followerPublish")}
+                      value={PublicState.Follower}
+                      style={{ cursor: "pointer" }}
+                    />
+                    <Mantine.Radio
+                      label={t_PostGeneral("private")}
+                      value={PublicState.Private}
+                      style={{ cursor: "pointer" }}
+                    />
+                  </Mantine.Group>
+                </Mantine.Radio.Group>
+                <p className="text-sm my-4">
+                  {t_PostGeneral("publishAttention")}
+                </p>
+              </section>
+              <section className="my-8">
+                <Mantine.Group className="flex justify-center items-center">
+                  <Mantine.Button
+                    type="submit"
+                    className="bg-green-300 text-black hover:bg-green-500 hover:text-black transition-all"
+                  >
+                    {t_PostGeneral("post")}
+                  </Mantine.Button>
+                  {Illust.publishRange === PublicState.Draft && (
+                    <Mantine.Button
+                      type="submit"
+                      onClick={() =>
+                        form.setValues({ publishRange: PublicState.Draft })
+                      }
+                      className="bg-slate-500 hover:bg-slate-800 transition-all"
+                    >
+                      {t_PostGeneral("draftSave")}
+                    </Mantine.Button>
+                  )}
+                  <Mantine.Button
+                    type="button"
+                    onClick={handleDelete}
+                    className="bg-red-500 hover:bg-red-800 transition-all"
+                  >
+                    {t_PostGeneral("delete")}
+                  </Mantine.Button>
+                </Mantine.Group>
+              </section>
+            </form>
+          </Mantine.Box>
+        </Mantine.Container>
+      </article>
+
+      <TransitionsModal onClose={handleModalClose}>
+        {isDelete ? (
+          <>
+            <h3 className="text-xl text-center my-4">
+              作品を削除します。
+              <br className="block md:hidden" />
+              よろしいですか？
+            </h3>
+            <p className="text-center text-sm">
+              ※作品を削除したらもとに戻せません
+            </p>
+            <div className="my-4 flex flex-col justify-center items-center">
+              <Mantine.Checkbox
+                label="作品を削除する"
+                size="md"
+                radius="xl"
+                color="red"
+                onChange={() => setIsDeleteConfirmation(!isDelete)}
+              />
+              {deleteConfirmationError && (
+                <p className="text-red-400">{deleteConfirmationError}</p>
+              )}
+            </div>
+            <div className="flex flex-col justify-center items-center gap-4 my-8">
+              <Mantine.Button
+                type="button"
+                className="bg-red-400 hover:bg-red-600 transition-all text-white px-8 py-1"
+                onClick={handleDeleteSubmit}
+              >
+                削除
+              </Mantine.Button>
+              <Mantine.Button
+                type="button"
+                className="tracking-wider text-black hover:text-black hover:text-opacity-50 transition-all bg-transparent hover:bg-transparent"
+                onClick={() => {
+                  setIsDelete(false);
+                  setOpenModal(false);
+                }}
+              >
+                戻る
+              </Mantine.Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h3 className="text-xl text-center my-4">
+              {form.values.publishRange === PublicState.Draft
+                ? t_PostGeneral("draftSaved")
+                : t_PostGeneral("posted")}
+            </h3>
+            <Mantine.Group justify="center" gap={8}>
+              {form.values.publishRange === PublicState.Draft ? (
+                <>
+                  <Mantine.Button
+                    className="bg-green-300 text-black"
+                    onClick={handleModalClose}
+                  >
+                    {t_PostGeneral("close")}
+                  </Mantine.Button>
+                </>
+              ) : (
+                <>
+                  <Mantine.Button
+                    className="bg-green-300 text-black"
+                    onClick={() => router.push(RouterPath.illust(Illust.id))}
+                  >
+                    {t_PostGeneral("showPost")}
+                  </Mantine.Button>
+                  <Mantine.Button className="bg-black text-white">
+                    {t_PostGeneral("XShare")}
+                  </Mantine.Button>
+                </>
+              )}
+            </Mantine.Group>
+          </>
+        )}
+      </TransitionsModal>
+    </>
+  );
 }

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -51,6 +51,8 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
   const user = useRecoilValue(userState);
   const t_PostIllustEdit = useTranslations("PostIllustEdit");
   const t_PostGeneral = useTranslations("PostGeneral");
+  const t_General = useTranslations("General");
+  const t_EditGeneral = useTranslations("EditGeneral");
   const [isDelete, setIsDelete] = useState<boolean>(false);
   const [isDeleteConfirmation, setIsDeleteConfirmation] =
     useState<boolean>(false);
@@ -94,7 +96,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
 
   const handleDeleteSubmit = () => {
     if (!isDeleteConfirmation) {
-      setDeleteConfirmationError("削除するにはチェックを入れてください");
+      setDeleteConfirmationError(t_EditGeneral("checkDeleteValid"));
       return;
     }
   };
@@ -133,7 +135,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                 color="transparent"
                 className="text-blue-500 hover:text-blue-300 transition-all hover:bg-transparent"
               >
-                戻る
+                {t_General("back")}
               </Mantine.Button>
             </div>
             <h1 className="text-center font-semibold my-4">
@@ -324,16 +326,14 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
         {isDelete ? (
           <>
             <h3 className="text-xl text-center my-4">
-              作品を削除します。
-              <br className="block md:hidden" />
-              よろしいですか？
+              {t_EditGeneral("deleteModalTItle")}
             </h3>
             <p className="text-center text-sm">
-              ※作品を削除したらもとに戻せません
+              {t_EditGeneral("deleteModalAttention")}
             </p>
             <div className="my-4 flex flex-col justify-center items-center">
               <Mantine.Checkbox
-                label="作品を削除する"
+                label={t_EditGeneral("deleteCheckLabel")}
                 size="md"
                 radius="xl"
                 color="red"
@@ -359,7 +359,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                   setOpenModal(false);
                 }}
               >
-                戻る
+                {t_General("back")}
               </Mantine.Button>
             </div>
           </>

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -123,6 +123,19 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
       <article className="mt-8 mb-12">
         <Mantine.Container size={"sm"}>
           <Mantine.Box className="bg-white p-4 px-8 rounded">
+            <div className="text-end">
+              <Mantine.Button
+                type="button"
+                onClick={() => {
+                  router.back();
+                }}
+                size="xs"
+                color="transparent"
+                className="text-blue-500 hover:text-blue-300 transition-all hover:bg-transparent"
+              >
+                戻る
+              </Mantine.Button>
+            </div>
             <h1 className="text-center font-semibold my-4">
               {t_PostIllustEdit("title")}
             </h1>

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { FormEvent, useState } from "react";
 import { useSetRecoilState } from "recoil";
 import * as RecoilState from "@/recoilState";
-import Style from "@/styles/index.module.css";
 import { Link } from "@/lib";
 import * as Mantine from "@mantine/core";
 import { FixedIconButtonList, IconButtonList } from "@/components/ui";

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -124,19 +124,16 @@ export default function IllustPostPage() {
                   {...form.getInputProps("postIllust")}
                 >
                   <Dropzone.Idle>
-                    {
-                      postIllust.length > 0 && (
-                        <Mantine.Image
-                          src={postIllust[0]}
-                          h={mobile ? "15rem" : "30rem"}
-                          w="auto"
-                          m="auto"
-                          fit="cover"
-                          className="opacity-50"
-                        />
-                      )
-                      // ))
-                    }
+                    {postIllust.length > 0 && (
+                      <Mantine.Image
+                        src={postIllust[0]}
+                        h={mobile ? "15rem" : "30rem"}
+                        w="auto"
+                        m="auto"
+                        fit="cover"
+                        className="opacity-50"
+                      />
+                    )}
                     <FaImage
                       className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
                       style={{
@@ -236,7 +233,7 @@ export default function IllustPostPage() {
                 <Mantine.Group className="flex justify-center items-center">
                   <Mantine.Button
                     type="submit"
-                    className="bg-green-300 text-black hover:bg-green-500 hover:text-black"
+                    className="bg-green-300 text-black hover:bg-green-500 hover:text-black transition-all"
                   >
                     {t_PostGeneral("post")}
                   </Mantine.Button>
@@ -245,7 +242,7 @@ export default function IllustPostPage() {
                     onClick={() =>
                       form.setValues({ publishRange: PublicState.Draft })
                     }
-                    className="bg-slate-500 hover:bg-slate-800"
+                    className="bg-slate-500 hover:bg-slate-800 transition-all"
                   >
                     {t_PostGeneral("draftSave")}
                   </Mantine.Button>

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -2,6 +2,7 @@ import { Link } from "@/lib";
 import { RouterPath } from "@/settings";
 import { IndexIllustData } from "@/types";
 import { Image } from "@mantine/core";
+import { useTranslations } from "next-intl";
 import dynamic from "next/dynamic";
 
 // aタグの中にsvgを入れるとHydrationエラーになるので動的読み込みを行う
@@ -18,8 +19,9 @@ export default function Illust({
   illust: IndexIllustData;
   isUserPage?: boolean;
 }) {
+  const t_General = useTranslations("General");
   return (
-    <section>
+    <section className="relative overflow-hidden">
       <Link href={RouterPath.illust(illust.id)} className="relative z-0">
         <Image
           src={illust.image}
@@ -28,10 +30,19 @@ export default function Illust({
           className="aspect-square object-cover z-10"
         />
         {illust.count > 1 && (
-          <MdCollections className="absolute bottom-2 right-2 text-white" />
+          <MdCollections className="absolute top-2 right-2 text-white" />
         )}
       </Link>
-      {!isUserPage && (
+      {isUserPage ? (
+        <div className="absolute bottom-0 right-0 text-sm text-end">
+          <Link
+            href={RouterPath.illustEdit(illust.id)}
+            className="px-2 py-1 bg-slate-600 text-white rounded-l"
+          >
+            {t_General("edit")}
+          </Link>
+        </div>
+      ) : (
         <div className="mt-2 flex ml-4 justify-start items-center gap-3">
           <Link href={`/users/${illust.user.id}`}>
             <Image

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -10,6 +10,7 @@ export const RouterPath = {
   illust: (id: number) => `/illusts/${id}`,
   illustSearch: (searchWord: string) => `/illusts?search=${searchWord}`,
   illustPost: "/illusts/post",
+  illustEdit: (id: number) => `/illusts/${id}/edit`,
   users: (id: number) => `/users/${id}`,
   account: "/account",
   bookmark: (id: number) => `/users/${id}?bookmark=true`,


### PR DESCRIPTION
# 概要
イラストの編集ページのガワを作成しました。

## 実装項目
- [x] 投稿したイラストが表示されていること
- [x] 投稿したイラストは変更できないこと
- [x] タイトルラベルと入力フォームがあること
- [x] タイトルフォームの初期値は投稿時（下書き保存時）のデータが表示されていること
- [x] キャプションラベルとテキストエリアがあること
- [x] キャプションフォームの初期値は投稿時（下書き保存時）のデータが表示されていること
- [x] タグラベルと入力フォームがあること
- [x] タグフォームの下に初期値データとして投稿時（下書き保存時）のデータが表示されていること
- [x] システムラベルとセレクトボックスがあること
- [x] セレクトボックスの初期値は投稿時（下書き保存時）のデータが表示されていること
- [x] 公開範囲ラベルとラジオボタンが表示されていること
- [x] 公開範囲の初期値は、投稿済みであれば投稿時の選択状態、下書き保存では何も選択されていない状態であること
- [x] 保存・削除ボタンがあること
- [x] 公開範囲が選択されている状態で保存を押すと、公開用のモーダルが表示されること
- [x] 下書き状態から公開状態が未選択で保存を押すと、下書き用のモーダルが表示されること
- [x] 削除ボタンを押すと削除用モーダルが表示されること
   - [x] 削除の文言が表示されること
   - [x] 削除の注意書き（一度消したら戻せないよ）が表示されていること
   - [x] 作品削除のチェックボックスが表示されていること
   - [x] 削除ボタンが表示されていること
   - [x] 作品削除のチェックボックスが未チェックの状態で削除ボタンを押すとバリデーションが発生すること
   - [x] チェックボックスがチェック状態で削除ボタンを押すと、削除してマイページに飛ぶこと
   - [x] 戻るボタンが表示されること
   - [x] チェックボックスのチェックの状態にかかわらず戻るボタンでモーダルが閉じること
   - [x] チェックボックスはモーダルを閉じたあとにもう一度開くと未選択の状態であること）

## 追加実装
- [x] マイページに編集ボタン実装
   ⇨投稿ユーザーとログインユーザーが一致するときのみ表示の実装は別で行います

## 未実装
削除後の動作は未実装です

## 挙動
| 全体公開PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/19b3fa564ae480da5c6aa2d9248c6b79.gif" width="470px" /> | <img src="https://i.gyazo.com/2caef42a12173e9fc8ef5361dc284e2c.gif" width="200px" /> |


| 下書きPC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/fa1b8f59ef70037772ca00561ce2c809.gif" width="450px" /> | <img src="https://i.gyazo.com/7873e54bea5ebcdaaab9dbd65c0e1248.gif" width="200px" /> |


| 削除PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/ebf0059a6cd26b7181648d9351d454f7.gif" width="450px" /> | <img src="https://i.gyazo.com/c0479c3cab91fddbb28ee41aa1ebfc9b.gif" width="200px" /> |