### PR TITLE
【fix】ヘッダーのレスポンシブ対応 resolves #125

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "@mantine/spotlight": "^7.8.1",
     "axios": "^1.6.8",
     "embla-carousel-react": "^8.0.2",
+    "framer-motion": "^11.1.9",
     "next": "14.2.1",
     "next-intl": "^3.11.1",
     "react": "^18",

--- a/front/src/components/features/illusts/illustCarousel.tsx
+++ b/front/src/components/features/illusts/illustCarousel.tsx
@@ -23,7 +23,6 @@ export default function IllustCarousel({
       <Carousel
         slideSize={slideSize}
         slideGap="xs"
-        loop
         align={align}
         slidesToScroll={slidesToScroll}
         className="h-full"

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -51,7 +51,7 @@ export default function Headers() {
 
   return (
     <>
-      <header className="p-2 flex justify-between items-center ml-2 md:mx-8 md:my-2">
+      <header className="p-2 flex justify-center md:justify-between items-center ml-2 md:mx-8 md:my-2">
         <h1>
           <Link href={RouterPath.home}>
             <Image

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -71,7 +71,7 @@ export default function Headers() {
               onSubmit={handleSearch}
             >
               <label className="bg-green-100 rounded md:text-sm md:flex md:justify-center md:items-center text-gray-400 pl-2">
-                <IoMdSearch />
+                <IoMdSearch className="icon-gray-500" />
                 <Mantine.TextInput
                   className="bg-green-100 focus:outline-none w-60 text-black"
                   placeholder={t_Header("searchPlaceholder")}

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -13,6 +13,7 @@ import * as Mantine from "@mantine/core";
 import { FaRegBookmark } from "rocketicons/fa";
 import { MdLogout } from "rocketicons/md";
 import { RouterPath } from "@/settings";
+import SpHeaders from "./spHeaders";
 
 export default function Headers() {
   const [user, setUser] = useRecoilState(RecoilState.userState);
@@ -20,7 +21,6 @@ export default function Headers() {
   const t_Header = useTranslations("Header");
   const [search, setSearch] = useState("");
   const router = useRouter();
-
   useEffect(() => {
     if (user.name !== "") return;
     const fetchData = async () => {
@@ -45,9 +45,13 @@ export default function Headers() {
     router.push(RouterPath.illustPost);
   };
 
+  const handleLogout = async () => {
+    // TODO : ログアウト処理をここに書く
+  };
+
   return (
     <>
-      <header className="flex justify-between items-center ml-2 md:mx-8 md:my-2">
+      <header className="p-2 flex justify-between items-center ml-2 md:mx-8 md:my-2">
         <h1>
           <Link href={RouterPath.home}>
             <Image
@@ -61,7 +65,7 @@ export default function Headers() {
           </Link>
         </h1>
         <div className="md:flex md:items-center md:justify-center md:gap-8">
-          <div className="md:flex md:flex-col md:justify-end md:items-start">
+          <div className="hidden md:flex md:flex-col md:justify-end md:items-start">
             <form
               className="md:flex md:justify-center md:items-center gap-2"
               onSubmit={handleSearch}
@@ -92,36 +96,43 @@ export default function Headers() {
               <Mantine.Button
                 variant="contained"
                 onClick={handlePost}
-                className="md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
+                className="hidden md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all"
               >
                 {t_Header("postButton")}
               </Mantine.Button>
-              <AccountMenu user={user} />
+              <div className="hidden md:block">
+                <AccountMenu user={user} handleLogout={handleLogout} />
+              </div>
             </>
           ) : (
             <Link
               href="/login"
-              className="p-2 px-3 rounded hidden md:block bg-orange-200 hover:bg-orange-400 text-black  transition-all hover:text-white"
+              className="text-sm md:text-normal p-2 px-3 rounded bg-orange-200 hover:bg-orange-400 text-black  transition-all hover:text-white"
             >
               {t_Header("signUpOrLogin")}
             </Link>
           )}
         </div>
       </header>
+
+      {/* SP */}
+      <SpHeaders user={user} handleLogout={handleLogout} />
     </>
   );
 }
 
-export function AccountMenu({ user }: { user: IUser }) {
+export function AccountMenu({
+  user,
+  handleLogout,
+}: {
+  user: IUser;
+  handleLogout: () => void;
+}) {
   const t_Menu = useTranslations("MyMenu");
   const router = useRouter();
 
   const handleLink = (path: string) => {
     router.push(`/${path}`);
-  };
-
-  const handleLogout = async () => {
-    // TODO : ログアウト処理をここに書く
   };
 
   return (

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import * as Mantine from "@mantine/core";
+import { IoMdSearch, IoMdSettings } from "rocketicons/io";
+import { LayoutGroup, motion } from "framer-motion";
+import { MdLogout } from "rocketicons/md";
+import { VscAccount } from "rocketicons/vsc";
+import { IUser } from "@/types";
+import { useRouter } from "@/lib";
+import { RouterPath } from "@/settings";
+
+export default function SpHeaders({
+  user,
+  handleLogout,
+}: {
+  user: IUser;
+  handleLogout: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [searchIconPos, setSearchIconPos] = useState({ x: 0, y: 0 });
+  const [avatarIconPos, setAvatarIconPos] = useState({ x: 0, y: 0 });
+  const [settingIconPos, setSettingIconPos] = useState({ x: 0, y: 0 });
+  const [logoutIconPos, setLogoutIconPos] = useState({ x: 0, y: 0 });
+  const router = useRouter();
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref]);
+
+  useEffect(() => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setSearchIconPos({ x: rect.right, y: rect.bottom });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    if (open) {
+      setAvatarIconPos({ x: rect.x + 3, y: rect.y - 85 });
+      setSearchIconPos({ x: rect.x - 45, y: rect.y - 75 });
+      setSettingIconPos({ x: rect.x - 75, y: rect.y - 35 });
+      setLogoutIconPos({ x: rect.x - 90, y: rect.y + 10 });
+    } else {
+      setAvatarIconPos({ x: rect.x, y: rect.y });
+      setSearchIconPos({ x: rect.x, y: rect.y });
+      setSettingIconPos({ x: rect.x, y: rect.y });
+      setLogoutIconPos({ x: rect.x, y: rect.y });
+    }
+  }, [open]);
+
+  return (
+    <>
+      <div
+        className={`${
+          open ? "block" : "hidden"
+        } md:hidden fixed bottom-0 right-0 w-full min-h-screen z-50 bg-black bg-opacity-40`}
+      >
+        <div className="relative w-full h-full">
+          <LayoutGroup>
+            {user.name && (
+              <motion.div
+                className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                animate={{ x: avatarIconPos.x, y: avatarIconPos.y }}
+                transition={{ type: "spring" }}
+              >
+                <Mantine.Button
+                  color="transparent"
+                  bg="transparent"
+                  className="w-full h-full p-0"
+                  onClick={() => router.push(RouterPath.users(user.id))}
+                >
+                  <VscAccount className="w-full h-full text-white" />
+                </Mantine.Button>
+              </motion.div>
+            )}
+            <motion.div
+              className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+              animate={{ x: searchIconPos.x, y: searchIconPos.y }}
+              transition={{ type: "spring" }}
+            >
+              <Mantine.Button
+                color="transparent"
+                bg="transparent"
+                className="w-full h-full p-0"
+              >
+                <IoMdSearch className="w-full h-full text-white" />
+              </Mantine.Button>
+            </motion.div>
+            {user.name && (
+              <>
+                <motion.div
+                  className="w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                  animate={{ x: settingIconPos.x, y: settingIconPos.y }}
+                  transition={{ type: "spring" }}
+                >
+                  <Mantine.Button
+                    color="transparent"
+                    bg="transparent"
+                    className="w-full h-full p-0"
+                    onClick={() => router.push(RouterPath.account)}
+                  >
+                    <IoMdSettings className="w-full h-full text-white" />
+                  </Mantine.Button>
+                </motion.div>
+                <motion.div
+                  className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                  animate={{ x: logoutIconPos.x, y: logoutIconPos.y }}
+                  transition={{ type: "spring" }}
+                >
+                  <Mantine.Button
+                    color="transparent"
+                    bg="transparent"
+                    className="w-full h-full p-0"
+                    onClick={handleLogout}
+                  >
+                    <MdLogout className="w-full h-full text-white" />
+                  </Mantine.Button>
+                </motion.div>
+              </>
+            )}
+          </LayoutGroup>
+        </div>
+      </div>
+      <div
+        id="sp-menu"
+        className="fixed bottom-4 right-4 z-50 w-14 h-14 flex justify-end items-end"
+      >
+        <div
+          ref={ref}
+          className="w-12 h-12 bg-green-300 rounded-full flex justify-center items-center cursor-pointer"
+        >
+          <Mantine.Button
+            color="transparent"
+            onClick={() => setOpen(!open)}
+            className="bg-transparent hover:bg-transparent p-0"
+          >
+            <MenuIconAnim open={open} />
+          </Mantine.Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function MenuIconAnim({ open = false }: { open: boolean }) {
+  return (
+    <svg
+      id="hamburger"
+      className="Header__toggle-svg bg-green-300 rounded-full w-12 h-12"
+      viewBox="0 0 60 40"
+    >
+      <g
+        stroke="#fff"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path
+          id="top-line"
+          className={open ? "activated" : ""}
+          d="M10,10 L50,10 Z"
+        ></path>
+        <path
+          id="middle-line"
+          className={open ? "activated" : ""}
+          d="M10,20 L50,20 Z"
+        ></path>
+        <path
+          id="bottom-line"
+          className={open ? "activated" : ""}
+          d="M10,30 L50,30 Z"
+        ></path>
+      </g>
+    </svg>
+  );
+}

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import * as Mantine from "@mantine/core";
+import * as UI from "@/components/ui";
 import { IoMdSearch, IoMdSettings } from "rocketicons/io";
 import { LayoutGroup, motion } from "framer-motion";
 import { MdLogout } from "rocketicons/md";
@@ -9,6 +10,9 @@ import { VscAccount } from "rocketicons/vsc";
 import { IUser } from "@/types";
 import { useRouter } from "@/lib";
 import { RouterPath } from "@/settings";
+import { useSetRecoilState } from "recoil";
+import { modalOpenState } from "@/recoilState";
+import { useTranslations } from "use-intl";
 
 export default function SpHeaders({
   user,
@@ -23,7 +27,10 @@ export default function SpHeaders({
   const [avatarIconPos, setAvatarIconPos] = useState({ x: 0, y: 0 });
   const [settingIconPos, setSettingIconPos] = useState({ x: 0, y: 0 });
   const [logoutIconPos, setLogoutIconPos] = useState({ x: 0, y: 0 });
+  const [search, setSearch] = useState("");
   const router = useRouter();
+  const setModalOpen = useSetRecoilState(modalOpenState);
+  const t_Header = useTranslations("Header");
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -62,9 +69,30 @@ export default function SpHeaders({
     }
   }, [open]);
 
+  const handleMenuOpen = () => {
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setModalOpen(false);
+    }
+  };
+
   const handleLink = (path: string) => {
     setOpen(false);
     router.push(path);
+  };
+
+  const handleSearchModal = (isOpen: boolean) => {
+    setModalOpen(isOpen);
+  };
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!search) return;
+    const searchWords = search.split(/\s|　/).join(",");
+    router.push(RouterPath.illustSearch(searchWords));
+    setOpen(false);
+    setModalOpen(false);
   };
 
   return (
@@ -90,6 +118,7 @@ export default function SpHeaders({
             className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
             animate={{ x: searchIconPos.x, y: searchIconPos.y }}
             transition={{ type: "spring" }}
+            onClick={() => handleSearchModal(true)}
           >
             <IoMdSearch className="w-full h-full text-white" />
           </motion.button>
@@ -125,13 +154,40 @@ export default function SpHeaders({
         >
           <Mantine.Button
             color="transparent"
-            onClick={() => setOpen(!open)}
+            onClick={handleMenuOpen}
             className="bg-transparent hover:bg-transparent p-0"
           >
             <MenuIconAnim open={open} />
           </Mantine.Button>
         </div>
       </div>
+      <UI.TransitionsModal centered>
+        <h2 className="text-center text-xl mb-4">検索</h2>
+        <form
+          className="flex flex-col justify-center items-center gap-2"
+          onSubmit={handleSearch}
+        >
+          <label className="bg-green-100 rounded text-sm flex justify-center items-center text-gray-400 pl-2">
+            <IoMdSearch />
+            <Mantine.TextInput
+              className="bg-green-100 focus:outline-none w-60 text-black"
+              placeholder={t_Header("searchPlaceholder")}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setSearch(e.target.value)
+              }
+              variant="transparent"
+            />
+          </label>
+          <Mantine.Button
+            type="submit"
+            variant="contained"
+            size="small"
+            className="bg-green-200 hover:bg-green-400 text-black transition-all"
+          >
+            {t_Header("searchButton")}
+          </Mantine.Button>
+        </form>
+      </UI.TransitionsModal>
     </>
   );
 }

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -27,7 +27,8 @@ export default function SpHeaders({
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
+      const tapNode = event.target as HTMLElement;
+      if (tapNode.id === "sp-menu-back") {
         setOpen(false);
       }
     }
@@ -61,78 +62,77 @@ export default function SpHeaders({
     }
   }, [open]);
 
+  const handleLink = (path: string) => {
+    console.log(path);
+    setOpen(false);
+    router.push(path);
+  };
+
   return (
     <>
       <div
+        id="sp-menu-back"
         className={`${
           open ? "block" : "hidden"
         } md:hidden fixed bottom-0 right-0 w-full min-h-screen z-50 bg-black bg-opacity-40`}
       >
-        <div className="relative w-full h-full">
-          <LayoutGroup>
-            {user.name && (
+        <LayoutGroup>
+          {user.name && (
+            <motion.button
+              className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+              animate={{ x: avatarIconPos.x, y: avatarIconPos.y }}
+              transition={{ type: "spring" }}
+              onClick={() => handleLink(RouterPath.users(user.id))}
+            >
+              <VscAccount className="w-full h-full text-white" />
+            </motion.button>
+          )}
+          <motion.div
+            className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+            animate={{ x: searchIconPos.x, y: searchIconPos.y }}
+            transition={{ type: "spring" }}
+          >
+            <Mantine.Button
+              color="transparent"
+              bg="transparent"
+              className="w-full h-full p-0"
+            >
+              <IoMdSearch className="w-full h-full text-white" />
+            </Mantine.Button>
+          </motion.div>
+          {user.name && (
+            <>
               <motion.div
-                className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
-                animate={{ x: avatarIconPos.x, y: avatarIconPos.y }}
+                className="w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                animate={{ x: settingIconPos.x, y: settingIconPos.y }}
                 transition={{ type: "spring" }}
               >
                 <Mantine.Button
                   color="transparent"
                   bg="transparent"
                   className="w-full h-full p-0"
-                  onClick={() => router.push(RouterPath.users(user.id))}
+                  onClick={() => handleLink(RouterPath.account)}
                 >
-                  <VscAccount className="w-full h-full text-white" />
+                  <IoMdSettings className="w-full h-full text-white" />
                 </Mantine.Button>
               </motion.div>
-            )}
-            <motion.div
-              className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
-              animate={{ x: searchIconPos.x, y: searchIconPos.y }}
-              transition={{ type: "spring" }}
-            >
-              <Mantine.Button
-                color="transparent"
-                bg="transparent"
-                className="w-full h-full p-0"
+              <motion.div
+                className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                animate={{ x: logoutIconPos.x, y: logoutIconPos.y }}
+                transition={{ type: "spring" }}
               >
-                <IoMdSearch className="w-full h-full text-white" />
-              </Mantine.Button>
-            </motion.div>
-            {user.name && (
-              <>
-                <motion.div
-                  className="w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
-                  animate={{ x: settingIconPos.x, y: settingIconPos.y }}
-                  transition={{ type: "spring" }}
+                <Mantine.Button
+                  color="transparent"
+                  bg="transparent"
+                  className="w-full h-full p-0"
+                  onClick={handleLogout}
                 >
-                  <Mantine.Button
-                    color="transparent"
-                    bg="transparent"
-                    className="w-full h-full p-0"
-                    onClick={() => router.push(RouterPath.account)}
-                  >
-                    <IoMdSettings className="w-full h-full text-white" />
-                  </Mantine.Button>
-                </motion.div>
-                <motion.div
-                  className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
-                  animate={{ x: logoutIconPos.x, y: logoutIconPos.y }}
-                  transition={{ type: "spring" }}
-                >
-                  <Mantine.Button
-                    color="transparent"
-                    bg="transparent"
-                    className="w-full h-full p-0"
-                    onClick={handleLogout}
-                  >
-                    <MdLogout className="w-full h-full text-white" />
-                  </Mantine.Button>
-                </motion.div>
-              </>
-            )}
-          </LayoutGroup>
-        </div>
+                  <MdLogout className="w-full h-full text-white" />
+                </Mantine.Button>
+              </motion.div>
+            </>
+          )}
+        </LayoutGroup>
       </div>
       <div
         id="sp-menu"

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -111,7 +111,7 @@ export default function SpHeaders({
               transition={{ type: "spring" }}
               onClick={() => handleLink(RouterPath.users(user.id))}
             >
-              <VscAccount className="w-full h-full text-white" />
+              <VscAccount className="w-full h-full icon-white" />
             </motion.button>
           )}
           <motion.button
@@ -120,7 +120,7 @@ export default function SpHeaders({
             transition={{ type: "spring" }}
             onClick={() => handleSearchModal(true)}
           >
-            <IoMdSearch className="w-full h-full text-white" />
+            <IoMdSearch className="w-full h-full icon-white" />
           </motion.button>
           {user.name && (
             <>
@@ -130,7 +130,7 @@ export default function SpHeaders({
                 transition={{ type: "spring" }}
                 onClick={() => handleLink(RouterPath.account)}
               >
-                <IoMdSettings className="w-full h-full text-white" />
+                <IoMdSettings className="w-full h-full icon-white" />
               </motion.button>
               <motion.button
                 className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
@@ -138,7 +138,7 @@ export default function SpHeaders({
                 transition={{ type: "spring" }}
                 onClick={handleLogout}
               >
-                <MdLogout className="w-full h-full text-white" />
+                <MdLogout className="w-full h-full icon-white" />
               </motion.button>
             </>
           )}
@@ -168,7 +168,7 @@ export default function SpHeaders({
           onSubmit={handleSearch}
         >
           <label className="bg-green-100 rounded text-sm flex justify-center items-center text-gray-400 pl-2">
-            <IoMdSearch />
+            <IoMdSearch className="icon-gray-600" />
             <Mantine.TextInput
               className="bg-green-100 focus:outline-none w-60 text-black"
               placeholder={t_Header("searchPlaceholder")}

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -63,7 +63,6 @@ export default function SpHeaders({
   }, [open]);
 
   const handleLink = (path: string) => {
-    console.log(path);
     setOpen(false);
     router.push(path);
   };
@@ -87,49 +86,31 @@ export default function SpHeaders({
               <VscAccount className="w-full h-full text-white" />
             </motion.button>
           )}
-          <motion.div
+          <motion.button
             className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
             animate={{ x: searchIconPos.x, y: searchIconPos.y }}
             transition={{ type: "spring" }}
           >
-            <Mantine.Button
-              color="transparent"
-              bg="transparent"
-              className="w-full h-full p-0"
-            >
-              <IoMdSearch className="w-full h-full text-white" />
-            </Mantine.Button>
-          </motion.div>
+            <IoMdSearch className="w-full h-full text-white" />
+          </motion.button>
           {user.name && (
             <>
-              <motion.div
+              <motion.button
                 className="w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
                 animate={{ x: settingIconPos.x, y: settingIconPos.y }}
                 transition={{ type: "spring" }}
+                onClick={() => handleLink(RouterPath.account)}
               >
-                <Mantine.Button
-                  color="transparent"
-                  bg="transparent"
-                  className="w-full h-full p-0"
-                  onClick={() => handleLink(RouterPath.account)}
-                >
-                  <IoMdSettings className="w-full h-full text-white" />
-                </Mantine.Button>
-              </motion.div>
-              <motion.div
+                <IoMdSettings className="w-full h-full text-white" />
+              </motion.button>
+              <motion.button
                 className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
                 animate={{ x: logoutIconPos.x, y: logoutIconPos.y }}
                 transition={{ type: "spring" }}
+                onClick={handleLogout}
               >
-                <Mantine.Button
-                  color="transparent"
-                  bg="transparent"
-                  className="w-full h-full p-0"
-                  onClick={handleLogout}
-                >
-                  <MdLogout className="w-full h-full text-white" />
-                </Mantine.Button>
-              </motion.div>
+                <MdLogout className="w-full h-full text-white" />
+              </motion.button>
             </>
           )}
         </LayoutGroup>

--- a/front/src/components/layouts/spHeaders.tsx
+++ b/front/src/components/layouts/spHeaders.tsx
@@ -4,9 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import * as Mantine from "@mantine/core";
 import * as UI from "@/components/ui";
 import { IoMdSearch, IoMdSettings } from "rocketicons/io";
-import { LayoutGroup, motion } from "framer-motion";
-import { MdLogout } from "rocketicons/md";
+import { ImPencil } from "rocketicons/im";
 import { VscAccount } from "rocketicons/vsc";
+import { MdLogout } from "rocketicons/md";
+import { LayoutGroup, motion } from "framer-motion";
 import { IUser } from "@/types";
 import { useRouter } from "@/lib";
 import { RouterPath } from "@/settings";
@@ -23,8 +24,9 @@ export default function SpHeaders({
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
-  const [searchIconPos, setSearchIconPos] = useState({ x: 0, y: 0 });
   const [avatarIconPos, setAvatarIconPos] = useState({ x: 0, y: 0 });
+  const [searchIconPos, setSearchIconPos] = useState({ x: 0, y: 0 });
+  const [pencilIconPos, setPencilIconPos] = useState({ x: 0, y: 0 });
   const [settingIconPos, setSettingIconPos] = useState({ x: 0, y: 0 });
   const [logoutIconPos, setLogoutIconPos] = useState({ x: 0, y: 0 });
   const [search, setSearch] = useState("");
@@ -57,13 +59,15 @@ export default function SpHeaders({
     if (!ref.current) return;
     const rect = ref.current.getBoundingClientRect();
     if (open) {
-      setAvatarIconPos({ x: rect.x + 3, y: rect.y - 85 });
-      setSearchIconPos({ x: rect.x - 45, y: rect.y - 75 });
-      setSettingIconPos({ x: rect.x - 75, y: rect.y - 35 });
+      setAvatarIconPos({ x: rect.x + 10, y: rect.y - 90 });
+      setSearchIconPos({ x: rect.x - 40, y: rect.y - 90 });
+      setPencilIconPos({ x: rect.x - 90, y: rect.y - 90 });
+      setSettingIconPos({ x: rect.x - 90, y: rect.y - 40 });
       setLogoutIconPos({ x: rect.x - 90, y: rect.y + 10 });
     } else {
       setAvatarIconPos({ x: rect.x, y: rect.y });
       setSearchIconPos({ x: rect.x, y: rect.y });
+      setPencilIconPos({ x: rect.x, y: rect.y });
       setSettingIconPos({ x: rect.x, y: rect.y });
       setLogoutIconPos({ x: rect.x, y: rect.y });
     }
@@ -125,7 +129,15 @@ export default function SpHeaders({
           {user.name && (
             <>
               <motion.button
-                className="w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
+                animate={{ x: pencilIconPos.x, y: pencilIconPos.y }}
+                transition={{ type: "spring" }}
+                onClick={() => handleLink(RouterPath.illustPost)}
+              >
+                <ImPencil className="w-full h-full icon-white" />
+              </motion.button>
+              <motion.button
+                className="absolute top-0 left-0 w-12 h-12 bg-green-300 hover:bg-green-400 rounded-full p-2 "
                 animate={{ x: settingIconPos.x, y: settingIconPos.y }}
                 transition={{ type: "spring" }}
                 onClick={() => handleLink(RouterPath.account)}

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -17,16 +17,16 @@ export function IconButtonList({
   return (
     <>
       <div className="hidden md:flex gap-2 justify-end items-center">
-        <ul className="flex justify-between items-center">
-          <li className="w-1/3 h-full text-center">
+        <ul className="flex justify-center items-center">
+          <li className="mx-2 h-full text-center">
             <FavoriteButton state={buttonState.favorite} />
           </li>
-          <li className="w-1/3 h-full text-center">
+          <li className="mx-2 h-full text-center">
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
           {publicState.valueOf() === PublicState.All && (
-            <li className="w-1/3 h-full text-center">
+            <li className="mx-2 h-full text-center">
               <ShareButton />
             </li>
           )}
@@ -53,15 +53,15 @@ export function FixedIconButtonList({
     <>
       <article className="fixed bottom-0 left-0 w-full md:hidden">
         <ul className="bg-white flex justify-center items-center py-3">
-          <li className="w-1/3 h-full text-center border-r border-slate-200">
+          <li className="h-full mx-2 text-center">
             <FavoriteButton state={buttonState.favorite} />
           </li>
-          <li className="w-1/3 h-full text-center">
+          <li className="h-full mx-2 text-center">
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
           {publicState.valueOf() === PublicState.Private && (
-            <li className="w-1/3 h-full text-center border-l border-slate-200">
+            <li className="h-full mx-2 text-center">
               <ShareButton />
             </li>
           )}

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -1,5 +1,6 @@
 import { ButtonState, PublicState } from "@/types";
 import { BookmarkButton, FavoriteButton, ShareButton } from ".";
+import { RequiredLoginModal } from "../modal";
 
 // PC・タブレット用いいねボタン・ブックマークボタン・シェアボタン
 export function IconButtonList({
@@ -14,22 +15,25 @@ export function IconButtonList({
   const currentUser = true; // TODO : ログインユーザーの状態
 
   return (
-    <div className="hidden md:flex gap-2 justify-end items-center">
-      <ul className="flex justify-between items-center">
-        <li className="w-1/3 h-full text-center">
-          <FavoriteButton state={buttonState.favorite} />
-        </li>
-        <li className="w-1/3 h-full text-center">
-          <BookmarkButton state={buttonState.bookmark} />
-        </li>
-        {/* 公開範囲が全体のときのみシェア可能 */}
-        {publicState.valueOf() === PublicState.All && (
+    <>
+      <div className="hidden md:flex gap-2 justify-end items-center">
+        <ul className="flex justify-between items-center">
           <li className="w-1/3 h-full text-center">
-            <ShareButton />
+            <FavoriteButton state={buttonState.favorite} />
           </li>
-        )}
-      </ul>
-    </div>
+          <li className="w-1/3 h-full text-center">
+            <BookmarkButton state={buttonState.bookmark} />
+          </li>
+          {/* 公開範囲が全体のときのみシェア可能 */}
+          {publicState.valueOf() === PublicState.All && (
+            <li className="w-1/3 h-full text-center">
+              <ShareButton />
+            </li>
+          )}
+        </ul>
+      </div>
+      <RequiredLoginModal />
+    </>
   );
 }
 
@@ -46,21 +50,24 @@ export function FixedIconButtonList({
   const currentUser = true; // TODO : ログインユーザーの状態
 
   return (
-    <article className="fixed bottom-0 left-0 w-full md:hidden">
-      <ul className="bg-white flex justify-between items-center py-3">
-        <li className="w-1/3 h-full text-center border-r border-slate-200">
-          <FavoriteButton state={buttonState.favorite} />
-        </li>
-        <li className="w-1/3 h-full text-center border-r border-slate-200">
-          <BookmarkButton state={buttonState.bookmark} />
-        </li>
-        {/* 公開範囲が全体のときのみシェア可能 */}
-        {publicState.valueOf() === PublicState.Private && (
-          <li className="w-1/3 h-full text-center">
-            <ShareButton />
+    <>
+      <article className="fixed bottom-0 left-0 w-full md:hidden">
+        <ul className="bg-white flex justify-center items-center py-3">
+          <li className="w-1/3 h-full text-center border-r border-slate-200">
+            <FavoriteButton state={buttonState.favorite} />
           </li>
-        )}
-      </ul>
-    </article>
+          <li className="w-1/3 h-full text-center">
+            <BookmarkButton state={buttonState.bookmark} />
+          </li>
+          {/* 公開範囲が全体のときのみシェア可能 */}
+          {publicState.valueOf() === PublicState.Private && (
+            <li className="w-1/3 h-full text-center border-l border-slate-200">
+              <ShareButton />
+            </li>
+          )}
+        </ul>
+      </article>
+      <RequiredLoginModal />
+    </>
   );
 }

--- a/front/src/components/ui/iconsButton/index.tsx
+++ b/front/src/components/ui/iconsButton/index.tsx
@@ -10,7 +10,7 @@ import { Button } from "@mantine/core";
 
 const FavoriteButton = ({ state }: { state: boolean }) => {
   const [favorite, setFavorite] = useState(state);
-  const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
+  const setModalOpen = useSetRecoilState(RecoilState.requireModalOpenState);
 
   const handleFavorite = (value: boolean) => {
     // TODO : ログインユーザーでなければログインや登録を促す
@@ -29,15 +29,15 @@ const FavoriteButton = ({ state }: { state: boolean }) => {
           variant="transparent"
           color="pink"
         >
-          <MdFavorite className="w-[30px]" />
+          <MdFavorite className="icon-red-400" />
         </Button>
       ) : (
         <Button
           onClick={() => handleFavorite(true)}
           variant="transparent"
-          color="gray"
+          className="p-0"
         >
-          <MdOutlineFavoriteBorder className="w-[30px]" />
+          <MdOutlineFavoriteBorder className="icon-gray-500" />
         </Button>
       )}
     </>
@@ -46,7 +46,7 @@ const FavoriteButton = ({ state }: { state: boolean }) => {
 
 const BookmarkButton = ({ state }: { state: boolean }) => {
   const [bookmark, setBookmark] = useState(state);
-  const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
+  const setModalOpen = useSetRecoilState(RecoilState.requireModalOpenState);
 
   const handleBookmark = (value: boolean) => {
     // TODO : ログインユーザーでなければログインや登録を促す
@@ -61,7 +61,7 @@ const BookmarkButton = ({ state }: { state: boolean }) => {
     <>
       {bookmark ? (
         <Button onClick={() => handleBookmark(false)} variant="transparent">
-          <FaBookmark className="w-[25px]" />
+          <FaBookmark className="icon-sky-500" />
         </Button>
       ) : (
         <Button
@@ -69,7 +69,7 @@ const BookmarkButton = ({ state }: { state: boolean }) => {
           variant="transparent"
           color="gray"
         >
-          <FaRegBookmark className="w-[25px]" />
+          <FaRegBookmark className="icon-gray-500" />
         </Button>
       )}
     </>

--- a/front/src/components/ui/iconsButton/index.tsx
+++ b/front/src/components/ui/iconsButton/index.tsx
@@ -68,6 +68,7 @@ const BookmarkButton = ({ state }: { state: boolean }) => {
           onClick={() => handleBookmark(true)}
           variant="transparent"
           color="gray"
+          className="p-0"
         >
           <FaRegBookmark className="icon-gray-500" />
         </Button>
@@ -82,8 +83,8 @@ const ShareButton = () => {
   };
 
   return (
-    <Button onClick={handleShare} variant="transparent">
-      <MdShare className="w-[25px]" />
+    <Button onClick={handleShare} variant="transparent" className="p-0">
+      <MdShare className="icon-blue-500 p-0" />
     </Button>
   );
 };

--- a/front/src/components/ui/modal/modal.tsx
+++ b/front/src/components/ui/modal/modal.tsx
@@ -7,9 +7,11 @@ import { Modal } from "@mantine/core";
 export default function TransitionsModal({
   children,
   onClose,
+  centered,
 }: {
   children: React.ReactNode;
   onClose?: () => void;
+  centered?: boolean;
 }) {
   const [open, setOpen] = useRecoilState(ModalState.modalOpenState);
   const title = useRecoilValue(ModalState.modalTitleState);
@@ -21,7 +23,12 @@ export default function TransitionsModal({
 
   return (
     <>
-      <Modal opened={open} onClose={handleClose} title={title}>
+      <Modal
+        opened={open}
+        onClose={handleClose}
+        title={title}
+        centered={centered}
+      >
         {children}
       </Modal>
     </>

--- a/front/src/components/ui/modal/requiredLoginModal.tsx
+++ b/front/src/components/ui/modal/requiredLoginModal.tsx
@@ -1,14 +1,16 @@
 import { useTranslations } from "next-intl";
 import * as RecoilState from "@/recoilState";
 import { useRouter } from "@/lib";
-import { useSetRecoilState } from "recoil";
-import { TransitionsModal } from ".";
+import { useRecoilState } from "recoil";
 import { RouterPath } from "@/settings";
+import * as Mantine from "@mantine/core";
 
 export default function RequiredLoginModal() {
   const t_Auth = useTranslations("Auth");
   const router = useRouter();
-  const setModalOpen = useSetRecoilState(RecoilState.modalOpenState);
+  const [modalOpen, setModalOpen] = useRecoilState(
+    RecoilState.requireModalOpenState
+  );
 
   const handleRequired = (path: string) => {
     setModalOpen(false);
@@ -16,7 +18,7 @@ export default function RequiredLoginModal() {
   };
 
   return (
-    <TransitionsModal>
+    <Mantine.Modal opened={modalOpen} onClose={() => setModalOpen(false)}>
       <div className="text-center">{t_Auth("requiredAuth")}</div>
       <div className="flex gap-4 justify-center items-center mt-4 w-68 m-auto">
         <button
@@ -32,6 +34,6 @@ export default function RequiredLoginModal() {
           {t_Auth("toLogin")}
         </button>
       </div>
-    </TransitionsModal>
+    </Mantine.Modal>
   );
 }

--- a/front/src/recoilState/index.ts
+++ b/front/src/recoilState/index.ts
@@ -1,4 +1,8 @@
-import { modalOpenState, modalTitleState } from "./modalState";
+import {
+  modalOpenState,
+  requireModalOpenState,
+  modalTitleState,
+} from "./modalState";
 import { userState } from "./userState";
 
-export { modalOpenState, modalTitleState, userState };
+export { modalOpenState, requireModalOpenState, modalTitleState, userState };

--- a/front/src/recoilState/modalState.ts
+++ b/front/src/recoilState/modalState.ts
@@ -10,3 +10,8 @@ export const modalTitleState = atom({
   key: "modalTitleState",
   default: "",
 });
+
+export const requireModalOpenState = atom({
+  key: "requireModalOpenState",
+  default: false,
+});

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-.icon-default {
-  fill: white;
-}
-
 /* Googleでログイン・新規登録 */
 .gsi-material-button {
   -moz-user-select: none;

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+.icon-default {
+  fill: white;
+}
+
 /* Googleでログイン・新規登録 */
 .gsi-material-button {
   -moz-user-select: none;
@@ -147,4 +151,68 @@ div.mantine-Dropzone-root {
     rgba(0, 0, 0, 1) 0%,
     rgba(0, 0, 0, 0) 100%
   );
+}
+
+/* SP用メニューアイコン */
+#top-line,
+#bottom-line,
+#middle-line {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+svg #top-line.activated {
+  animation: down-rotate 0.6s ease-out both;
+}
+
+svg #bottom-line.activated {
+  animation: up-rotate 0.6s ease-out both;
+}
+
+svg #middle-line.activated {
+  animation: hide 0.6s ease-out forwards;
+}
+
+@keyframes up-rotate {
+  0% {
+    animation-timing-function: cubic-bezier(0.16, -0.88, 0.97, 0.53);
+    transform: translateY(0px);
+  }
+  30% {
+    transform-origin: center;
+    animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform: translateY(-10px);
+  }
+  100% {
+    transform-origin: center;
+    transform: translateY(-10px) rotate(45deg) scale(0.9);
+  }
+}
+
+@keyframes down-rotate {
+  0% {
+    animation-timing-function: cubic-bezier(0.16, -0.88, 0.97, 0.53);
+    transform: translateY(0px);
+  }
+  30% {
+    transform-origin: center;
+    animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform: translateY(10px);
+  }
+  100% {
+    transform-origin: center;
+    transform: translateY(10px) rotate(-45deg) scale(0.9);
+  }
+}
+
+@keyframes hide {
+  29% {
+    opacity: 1;
+  }
+  30% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1641,6 +1641,13 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+framer-motion@^11.1.9:
+  version "11.1.9"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.1.9.tgz#1ef021fc35615eb83d6baa903a47ba872be99187"
+  integrity sha512-flECDIPV4QDNcOrDafVFiIazp8X01HFpzc01eDKJsdNH/wrATcYydJSH9JbPWMS8UD5lZlw+J1sK8LG2kICgqw==
+  dependencies:
+    tslib "^2.4.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
# 概要
ヘッダーのレスポンシブ対応ができていなかったので、SP用に修正しました。

## 補足
ログアウトは未実装なのでボタンだけあります。
ホームへ戻るボタンが必要か検討の余地があります（今回は未実装）
アイコンのアニメーションは[Framer](https://www.framer.com/)を利用しています

## 挙動
[![Image from Gyazo](https://i.gyazo.com/031e2c81b5b112dd7415040aecfc6d92.gif)](https://gyazo.com/031e2c81b5b112dd7415040aecfc6d92)