### PR TITLE
【hotfix】本環境でDBが作成されるよう修正 close #121

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -11,9 +11,9 @@ RUN bundle install
 
 COPY . /app
 
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
+COPY ./bin/docker-entrypoint /usr/bin/
+RUN chmod +x /usr/bin/docker-entrypoint
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3000
 

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -13,7 +13,7 @@ COPY . /app
 
 COPY ./bin/docker-entrypoint /usr/bin/
 RUN chmod +x /usr/bin/docker-entrypoint
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint"]
 
 EXPOSE 3000
 

--- a/back/bin/docker-entrypoint
+++ b/back/bin/docker-entrypoint
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
 # If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
-  ./bin/rails db:prepare
-fi
+./bin/rails db:prepare
 
 exec "${@}"

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  root 'application#index'
-  
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth',controllers: {

--- a/back/entrypoint.sh
+++ b/back/entrypoint.sh
@@ -3,8 +3,4 @@ set -e
 
 rm -f /app/tmp/pids/server.pid
 
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
-  ./bin/rails db:prepare
-fi
-
 exec "$@"


### PR DESCRIPTION
# 概要
本環境でDBが作成されない不具合があったため修正しました。

## 原因
- 本環境用で使用しているDockerfileのentrypointが開発環境と同じものを使用していた
- 開発環境では手動でマイグレーションするため、entyrpointにはDB作成のコマンドがない

上記２つの原因から本環境でも手動でマイグレーションしなければならない状態でした。
GitHub連携していることと、CLI導入のコストが高かったためCLIを導入して手動マイグレーションをするようにはせず、bin/docker-entrypointを利用し本環境ではマイグレーションするようにしました。

## 補足
seedも自動実行されてしまうので注意が必要です。