### PR TITLE
【hotfix】PC画面でSP用メニューボタンを非表示に修正 resolves #125

### DIFF
--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -116,7 +116,9 @@ export default function Headers() {
       </header>
 
       {/* SP */}
-      <SpHeaders user={user} handleLogout={handleLogout} />
+      <div className="md:hidden">
+        <SpHeaders user={user} handleLogout={handleLogout} />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
# 概要
PC画面でSP用のメニューボタンが表示されていたので非表示に修正しました