### PR TITLE
【feature】バックエンドの画像投稿処理 close #63

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=linux/amd64 ruby:3.2.2
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client libvips
 
 WORKDIR /app
 

--- a/back/Dockerfile.dev
+++ b/back/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM ruby:3.2.2
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client libvips
 
 WORKDIR /app
 

--- a/back/Dockerfile.dev
+++ b/back/Dockerfile.dev
@@ -15,15 +15,6 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
-# ビルド時の引数を定義
-ARG USERNAME
-# 環境変数を設定
-ENV USERNAME ${USERNAME}
-
-# 環境変数を使用
-RUN if [ "$USERNAME" != "root" ]; then useradd $USERNAME --create-home --shell /bin/bash; fi && \
-  chown -R $USERNAME:$USERNAME db log storage tmp
-
 EXPOSE 3000
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "3.2.2"
 gem "rails", "~> 7.1.3", ">= 7.1.3.2"
 
+# postgre
 gem "pg", "~> 1.1"
 
 gem "puma", ">= 5.0"
@@ -10,8 +11,11 @@ gem "puma", ">= 5.0"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
+# 画像加工
+gem "mini_magick"
 gem "image_processing", "~> 1.2"
 
+# CORS対策
 gem "rack-cors"
 
 group :development, :test do
@@ -21,6 +25,7 @@ group :development, :test do
 end
 
 group :production do
+  # 画像保存のストレージサービス
   gem "aws-sdk-s3", require: false
 end
 

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -1,50 +1,27 @@
 source "https://rubygems.org"
 
 ruby "3.2.2"
-
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3", ">= 7.1.3.2"
 
-# Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 
-# Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-# gem "jbuilder"
-
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
-
-# Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem "rack-cors"
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem "pry-byebug"
   gem 'annotate' # モデルのスキーマを表示する
 end
 
-group :development do
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
+group :production do
+  gem "aws-sdk-s3", require: false
 end
 
 # .envを使うため

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -87,6 +87,22 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.927.0)
+    aws-sdk-core (3.195.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.80.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.149.1)
+      aws-sdk-core (~> 3, >= 3.194.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
@@ -133,6 +149,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     jwt (2.8.1)
@@ -283,6 +300,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  aws-sdk-s3
   bootsnap
   debug
   devise
@@ -291,6 +309,7 @@ DEPENDENCIES
   dotenv-rails
   image_processing (~> 1.2)
   jsonapi-serializer
+  mini_magick
   omniauth
   omniauth-discord
   omniauth-google-oauth2

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -120,11 +120,15 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -143,6 +147,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -252,6 +257,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -282,6 +289,7 @@ DEPENDENCIES
   devise-i18n
   devise_token_auth (>= 1.2.0)!
   dotenv-rails
+  image_processing (~> 1.2)
   jsonapi-serializer
   omniauth
   omniauth-discord

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::PostsController < Api::V1::BasesController
+  def create
+    post = current_api_v1_user.posts.build(post_params)
+    if post_params[:publish_state] != "draft"
+      post.published_at = Time.now
+    end
+
+    begin
+      post.save!
+      render json: post, status: :created
+    rescue => e
+      logger.error(e)
+      render json: { message: '投稿に失敗しました' }, status: :internal_server_error
+    end
+  end
+
+  private
+
+  def post_params
+    params.permit(:title, :caption, :content_kind, :publish_state)
+  end
+end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,3 +1,5 @@
+require 'mini_magick'
+
 class Api::V1::PostsController < Api::V1::BasesController
   # 全体のエラーハンドリング
   # TODO : 特定のエラーのみ捕捉するよう修正
@@ -9,20 +11,34 @@ class Api::V1::PostsController < Api::V1::BasesController
   def create
     post = current_api_v1_user.posts.build(post_params.except(:postable_attributes))
 
-    # 投稿タイプに応じたクラス
-    postable_type = post_params[:postable_type].constantize
-    # 投稿タイプのクラスをインスタンス
-    post.postable = postable_type.new(post_params[:postable_attributes])
-
     # 下書き以外は投稿日時保存
     if !post.draft?
       post.published_at = Time.now
     end
 
+    # 投稿タイプに応じたクラス
+    postable_type = post_params[:postable_type].constantize
+    # 投稿タイプのクラスをインスタンス
+    post.postable = postable_type.new
+
+    # イラストの場合
+    # TODO : 別の場所に書いたほうが良さそうな気がする
+    if post.illust?
+      decoded_image = Base64.decode64(post_params[:postable_attributes][:image])
+      image = MiniMagick::Image.read(decoded_image)
+      image.format 'webp'
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new(image.to_blob),
+        filename: SecureRandom.uuid,
+        content_type: 'image/webp'
+      )
+      post.postable.image.attach(blob)
+    end
+
     # 保存
     post.save!
 
-    render json: post, status: :created
+    head :created
   end
 
   private

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,22 +1,33 @@
 class Api::V1::PostsController < Api::V1::BasesController
+  # 全体のエラーハンドリング
+  # TODO : 特定のエラーのみ捕捉するよう修正
+  rescue_from StandardError do |e|
+    logger.error(e)
+    render json: { message: '失敗しました' }, status: :bad_request
+  end
+
   def create
-    post = current_api_v1_user.posts.build(post_params)
-    if post_params[:publish_state] != "draft"
+    post = current_api_v1_user.posts.build(post_params.except(:postable_attributes))
+
+    # 投稿タイプに応じたクラス
+    postable_type = post_params[:postable_type].constantize
+    # 投稿タイプのクラスをインスタンス
+    post.postable = postable_type.new(post_params[:postable_attributes])
+
+    # 下書き以外は投稿日時保存
+    if !post.draft?
       post.published_at = Time.now
     end
 
-    begin
-      post.save!
-      render json: post, status: :created
-    rescue => e
-      logger.error(e)
-      render json: { message: '投稿に失敗しました' }, status: :internal_server_error
-    end
+    # 保存
+    post.save!
+
+    render json: post, status: :created
   end
 
   private
 
   def post_params
-    params.permit(:title, :caption, :content_kind, :publish_state)
+    params.require(:post).permit(:title, :caption, :publish_state, :postable_type,postable_attributes: [:image])
   end
 end

--- a/back/app/models/authentication.rb
+++ b/back/app/models/authentication.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: authentictions
+# Table name: authentications
 #
 #  id         :bigint           not null, primary key
 #  provider   :string           not null

--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -9,4 +9,5 @@
 #
 class Illust < ApplicationRecord
   has_one :post, as: :postable, dependent: :destroy
+  has_one_attached :image
 end

--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: illusts
+#
+#  id         :bigint           not null, primary key
+#  image      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Illust < ApplicationRecord
+  has_one :post, as: :postable, dependent: :destroy
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -3,7 +3,6 @@
 # Table name: posts
 #
 #  id            :bigint           not null, primary key
-#  content_kind  :integer          default(0)
 #  title         :string           not null
 #  caption       :string
 #  publish_state :integer
@@ -11,11 +10,20 @@
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  user_id       :bigint
+#  postable_type :string           not null
+#  postable_id   :bigint           not null
 #
 class Post < ApplicationRecord
   belongs_to :user
+  belongs_to :postable, polymorphic: true
+  accepts_nested_attributes_for :postable
+
   validates :title, presence: true, length: { maximum: 20 }
   validates :caption, length: { maximum: 10_000 }
   enum publish_state: { draft: 0, all_publish: 1, only_url: 2, only_follower: 3, private_publish:4 }
-  enum content_kind: { illust: 0 }
+
+  # 投稿タイプがイラストか
+  def illust?
+    postable.is_a?(Illust)
+  end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id            :bigint           not null, primary key
+#  content_kind  :integer          default(0)
+#  title         :string           not null
+#  caption       :string
+#  publish_state :integer
+#  published_at  :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :bigint
+#
+class Post < ApplicationRecord
+  belongs_to :user
+  validates :title, presence: true, length: { maximum: 20 }
+  validates :caption, length: { maximum: 10_000 }
+  enum publish_state: { draft: 0, all_publish: 1, only_url: 2, only_follower: 3, private_publish:4 }
+  enum content_kind: { illust: 0 }
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ActiveRecord::Base
   has_one :profile, dependent: :destroy
   has_many :user_notices, dependent: :destroy
   has_many :notices, through: :user_notices
+  has_many :posts, dependent: :destroy
 
   # フォローしている人とフォローされている人を取得するためのアソシエーション
   has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy, inverse_of: :follower

--- a/back/app/serializers/notice_serializer.rb
+++ b/back/app/serializers/notice_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: notices
+#
+#  id         :bigint           not null, primary key
+#  favorite   :boolean          default(FALSE), not null
+#  bookmark   :boolean          default(FALSE), not null
+#  comment    :boolean          default(FALSE), not null
+#  follower   :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class NoticeSerializer
   include JSONAPI::Serializer
 

--- a/back/app/serializers/user_notice_serializer.rb
+++ b/back/app/serializers/user_notice_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_notices
+#
+#  id          :bigint           not null, primary key
+#  notice_kind :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint
+#  notice_id   :bigint
+#
 class UserNoticeSerializer
   include JSONAPI::Serializer
   attributes :notice_kind

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
+      resources :posts, only: %i[create]
     end
   end
 end

--- a/back/config/storage.yml
+++ b/back/config/storage.yml
@@ -6,29 +6,9 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+amazon:
+  service: S3
+  access_key_id: <%= ENV['ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['SECRET_ACCESS_KEY'] %>
+  region:
+  bucket: <%= ENV['OWN_BUCKET'] %>

--- a/back/db/migrate/20240510134134_create_posts.rb
+++ b/back/db/migrate/20240510134134_create_posts.rb
@@ -1,0 +1,15 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.integer :content_kind, default: 0
+      t.string :title, null: false
+      t.string :caption
+      t.integer :publish_state
+      t.datetime :published_at
+
+      t.timestamps
+    end
+
+    add_reference :posts, :user, foreign_key: true
+  end
+end

--- a/back/db/migrate/20240510134134_create_posts.rb
+++ b/back/db/migrate/20240510134134_create_posts.rb
@@ -1,7 +1,6 @@
 class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
-      t.integer :content_kind, default: 0
       t.string :title, null: false
       t.string :caption
       t.integer :publish_state
@@ -11,5 +10,6 @@ class CreatePosts < ActiveRecord::Migration[7.1]
     end
 
     add_reference :posts, :user, foreign_key: true
+    add_reference :posts, :postable, polymorphic: true,null: false
   end
 end

--- a/back/db/migrate/20240511024300_create_illusts.rb
+++ b/back/db/migrate/20240511024300_create_illusts.rb
@@ -1,0 +1,9 @@
+class CreateIllusts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :illusts do |t|
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/migrate/20240511041758_create_active_storage_tables.active_storage.rb
+++ b/back/db/migrate/20240511041758_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_05_021607) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_10_134134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_021607) do
     t.boolean "follower", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "content_kind", default: 0
+    t.string "title", null: false
+    t.string "caption"
+    t.integer "publish_state"
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -77,6 +89,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_021607) do
   end
 
   add_foreign_key "authentications", "users"
+  add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"
   add_foreign_key "relationships", "users", column: "followed_id"
   add_foreign_key "relationships", "users", column: "follower_id"

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_11_024300) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_041758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "authentications", force: :cascade do |t|
     t.string "provider", null: false
@@ -96,6 +124,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_024300) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authentications", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_134134) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_024300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_134134) do
     t.index ["user_id"], name: "index_authentications_on_user_id"
   end
 
+  create_table "illusts", force: :cascade do |t|
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "notices", force: :cascade do |t|
     t.boolean "favorite", default: false, null: false
     t.boolean "bookmark", default: false, null: false
@@ -34,7 +40,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_134134) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.integer "content_kind", default: 0
     t.string "title", null: false
     t.string "caption"
     t.integer "publish_state"
@@ -42,6 +47,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_134134) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "postable_type", null: false
+    t.bigint "postable_id", null: false
+    t.index ["postable_type", "postable_id"], name: "index_posts_on_postable"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     build:
       context: ./back
       dockerfile: Dockerfile.dev
-      args:
-        USERNAME: ${USERNAME}
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0'"
     volumes:
       - ./back:/app

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -49,8 +49,8 @@ export interface UserPageEdit {
 }
 
 export enum PublicState {
-  All = "All",
   Draft = "Draft",
+  All = "All",
   URL = "URL",
   Follower = "Follower",
   Private = "Private",


### PR DESCRIPTION
# 概要
Postmanを使い画像の保存処理を実装しました。

## 実装項目
- [x] イラストがDBに追加されファイルはストレージサービスに保存されること
   ⇨本環境で使用するS3への確認は #136 にて行います
- [x] タイトルが追加されること
- [x] キャプションが追加されること
- [x] 公開範囲が設定されること
- [x] コンテンツタイプがillustで設定されること

## 追加実装
- [x] 下書き以外は公開時間を保存する

## 補足
- ポリモーフィック関連付けで作成したため、カラム名が`content_type`から`postable_type`に変更しています
- `publish_range`を`publish_state`に変更しました

## 挙動
| Postman送信データ | コンソールから確認したデータ |
| --- | --- |
| <img src="https://i.gyazo.com/b2a85e48743631b4e88311f0312a832d.png"  width="500px" /> | <img src="https://i.gyazo.com/18c21afc172dc686b2e120e2e05fb14f.png"  width="300px" /> |

## 実装にあたり参考にしたもの
[Railsガイド Active Strorageの概要](https://railsguides.jp/active_storage_overview.html)
[[Rails]Active Storageの画像をAWS S3へ保存する](https://zenn.dev/redheadchloe/articles/e924ab767b40d5)
[【Rails】ActiveStorageで、保存する前に画像を縮小する方法](https://qiita.com/yoma2003/items/c2b81d6a80c0a654016d)
[画像→Base64エンコード](https://rakko.tools/tools/72/)
[Gem MiniMagick](https://github.com/minimagick/minimagick)

## 追加したもの
[Gem MiniMagick](https://github.com/minimagick/minimagick)