### PR TITLE
【feature】投稿処理のフロントとバックの連携 close #64

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=linux/amd64 ruby:3.2.2
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client libvips
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client libvips imagemagick
 
 WORKDIR /app
 

--- a/back/Dockerfile.dev
+++ b/back/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM ruby:3.2.2
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client libvips
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client libvips imagemagick
 
 WORKDIR /app
 

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -24,7 +24,11 @@ class Api::V1::PostsController < Api::V1::BasesController
     # イラストの場合
     # TODO : 別の場所に書いたほうが良さそうな気がする
     if post.illust?
-      decoded_image = Base64.decode64(post_params[:postable_attributes][:image])
+      # 送信されるデータは data: から始まるためエンコードデータのみ抽出
+      data = post_params[:postable_attributes][:image]
+      base64_data = data.split(",")[1]
+      decoded_image = Base64.decode64(base64_data)
+      # MiniMagickでwebpに軽量化
       image = MiniMagick::Image.read(decoded_image)
       image.format 'webp'
       blob = ActiveStorage::Blob.create_and_upload!(
@@ -38,7 +42,7 @@ class Api::V1::PostsController < Api::V1::BasesController
     # 保存
     post.save!
 
-    head :created
+    render json: { id: post.id }, status: :created
   end
 
   private

--- a/front/src/app/[locale]/account/page.tsx
+++ b/front/src/app/[locale]/account/page.tsx
@@ -80,7 +80,7 @@ export default function AccountPage() {
           <h3 className="text-xl font-semibold text-center mt-10 mb-2">
             {t_AccountSettings("notificationSettings")}
           </h3>
-          <NoticeTabs noticeStates={data.notices} />
+          <NoticeTabs INoticeStates={data.notices} />
         </section>
       </div>
     </article>

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -4,7 +4,7 @@ import { TransitionsModal } from "@/components/ui";
 import { useRouter } from "@/lib";
 import { modalOpenState, userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
-import { PublicState } from "@/types";
+import { IPublicState } from "@/types";
 import * as Mantine from "@mantine/core";
 import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
@@ -37,7 +37,7 @@ const Illust = {
   caption: "キャプション",
   gameSystem: "システム1",
   synalioTitle: "シナリオ名",
-  publishRange: PublicState.All,
+  publishRange: IPublicState.All,
   Tags: ["タグ1", "タグ2"],
 };
 
@@ -114,7 +114,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
     setIsDelete(false);
     setIsDeleteConfirmation(false);
     setDeleteConfirmationError("");
-    if (form.values.publishRange !== PublicState.Draft && !isDelete) {
+    if (form.values.publishRange !== IPublicState.Draft && !isDelete) {
       router.push(RouterPath.users(user.id));
     }
     setOpenModal(false);
@@ -146,7 +146,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
               onSubmit={form.onSubmit(handleSubmit)}
             >
               <section>
-                {Illust.publishRange === PublicState.Draft ? (
+                {Illust.publishRange === IPublicState.Draft ? (
                   <>
                     <label htmlFor="postIllust">
                       {t_PostIllustEdit("upload")}
@@ -265,22 +265,22 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                   <Mantine.Group>
                     <Mantine.Radio
                       label={t_PostGeneral("allPublish")}
-                      value={PublicState.All}
+                      value={IPublicState.All}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("urlPublish")}
-                      value={PublicState.URL}
+                      value={IPublicState.URL}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("followerPublish")}
-                      value={PublicState.Follower}
+                      value={IPublicState.Follower}
                       style={{ cursor: "pointer" }}
                     />
                     <Mantine.Radio
                       label={t_PostGeneral("private")}
-                      value={PublicState.Private}
+                      value={IPublicState.Private}
                       style={{ cursor: "pointer" }}
                     />
                   </Mantine.Group>
@@ -297,11 +297,11 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                   >
                     {t_PostGeneral("post")}
                   </Mantine.Button>
-                  {Illust.publishRange === PublicState.Draft && (
+                  {Illust.publishRange === IPublicState.Draft && (
                     <Mantine.Button
                       type="submit"
                       onClick={() =>
-                        form.setValues({ publishRange: PublicState.Draft })
+                        form.setValues({ publishRange: IPublicState.Draft })
                       }
                       className="bg-slate-500 hover:bg-slate-800 transition-all"
                     >
@@ -366,12 +366,12 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
         ) : (
           <>
             <h3 className="text-xl text-center my-4">
-              {form.values.publishRange === PublicState.Draft
+              {form.values.publishRange === IPublicState.Draft
                 ? t_PostGeneral("draftSaved")
                 : t_PostGeneral("posted")}
             </h3>
             <Mantine.Group justify="center" gap={8}>
-              {form.values.publishRange === PublicState.Draft ? (
+              {form.values.publishRange === IPublicState.Draft ? (
                 <>
                   <Mantine.Button
                     className="bg-green-300 text-black"

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -9,7 +9,7 @@ import { FixedIconButtonList, IconButtonList } from "@/components/ui";
 import { useTranslations } from "next-intl";
 import { useMediaQuery } from "@mantine/hooks";
 import { MdCollections } from "rocketicons/md";
-import { PublicState } from "@/types";
+import { IPublicState } from "@/types";
 
 export default function IllustPage({
   params: { id },
@@ -95,7 +95,7 @@ export default function IllustPage({
                   <IconButtonList
                     postId={id}
                     buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-                    publicState={PublicState.All} // TODO : 投稿の公開範囲
+                    publicState={IPublicState.All} // TODO : 投稿の公開範囲
                   />
                   <h3 className="text-2xl font-semibold">
                     タイトルタイトルタイトルタイトルタイトルタイトルタイトル
@@ -302,7 +302,7 @@ export default function IllustPage({
       <FixedIconButtonList
         postId={id}
         buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-        publicState={PublicState.All} // TODO : 投稿の公開範囲
+        publicState={IPublicState.All} // TODO : 投稿の公開範囲
       />
     </article>
   );

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TransitionsModal } from "@/components/ui";
 import { Post2API, useRouter } from "@/lib";
 import { userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
@@ -86,7 +85,7 @@ export default function IllustPostPage() {
     try {
       const res = await Post2API("/posts", JSON.stringify(post));
 
-      if (res.status != 200) {
+      if (res.status != 201) {
         const state = publishRange === IPublicState.Draft ? "保存" : "投稿";
         setErrorMessage(`${state}に失敗しました`);
         return;
@@ -94,7 +93,7 @@ export default function IllustPostPage() {
 
       setPostId(res.data.id);
     } catch (e) {
-      console.log(e);
+      console.error(e);
     } finally {
       setModalOpen(true);
     }
@@ -110,7 +109,10 @@ export default function IllustPostPage() {
   };
 
   const handleModalClose = () => {
-    if (form.values.publishRange !== IPublicState.Draft) {
+    if (
+      errorMessage === "" &&
+      form.values.publishRange !== IPublicState.Draft
+    ) {
       router.push(RouterPath.users(user.id));
     }
     setModalOpen(false);
@@ -278,9 +280,7 @@ export default function IllustPostPage() {
       </article>
 
       <Mantine.Modal opened={modalOpen} onClose={handleModalClose}>
-        {errorMessage ? (
-          <p>{errorMessage}</p>
-        ) : (
+        {errorMessage === "" ? (
           <>
             <h3 className="text-xl text-center my-4">
               {form.values.publishRange === IPublicState.Draft
@@ -312,6 +312,8 @@ export default function IllustPostPage() {
               )}
             </Mantine.Group>
           </>
+        ) : (
+          <p className="text-center">{errorMessage}</p>
         )}
       </Mantine.Modal>
     </>

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 import * as Mantine from "@mantine/core";
 import * as UI from "@/components/ui";
-import { IndexIllustData, UserPageEdit } from "@/types";
+import { IndexIllustData, IUserPageEdit } from "@/types";
 import { Illust } from "@/components/features/illusts";
 import { useTranslations } from "next-intl";
 import * as Users from "@/components/features/users";
@@ -33,7 +33,7 @@ export default function UserPage() {
     },
     profile:
       "プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文プロフィール文",
-  } as UserPageEdit;
+  } as IUserPageEdit;
 
   return (
     <>

--- a/front/src/components/features/account/notice.tsx
+++ b/front/src/components/features/account/notice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { NoticeState, NoticeStates } from "@/types";
+import { INoticeState, INoticeStates } from "@/types";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import * as Mantine from "@mantine/core";
@@ -15,19 +15,19 @@ interface TabPanelProps {
   children?: React.ReactNode;
   index: string;
   value: string;
-  noticeState: NoticeState;
-  setNewNoticeState: React.Dispatch<React.SetStateAction<NoticeStates>>;
+  INoticeState: INoticeState;
+  setNewNoticeState: React.Dispatch<React.SetStateAction<INoticeStates>>;
 }
 
 export default function NoticeTabs({
-  noticeStates,
+  INoticeStates,
 }: {
-  noticeStates: NoticeStates;
+  INoticeStates: INoticeStates;
 }) {
   const [value, setValue] = useState<string>(NoticeType.app);
   const t_AccountSettings = useTranslations("AccountSettings");
   const [newNoticeState, setNewNoticeState] =
-    useState<NoticeStates>(noticeStates);
+    useState<INoticeStates>(INoticeStates);
   const t_General = useTranslations("General");
 
   const handleChange = (newValue: string | null) => {
@@ -66,7 +66,7 @@ export default function NoticeTabs({
           <NoticePanel
             value={value}
             index={NoticeType.app}
-            noticeState={newNoticeState.app}
+            INoticeState={newNoticeState.app}
             setNewNoticeState={setNewNoticeState}
           />
         </Mantine.Tabs.Panel>
@@ -74,7 +74,7 @@ export default function NoticeTabs({
           <NoticePanel
             value={value}
             index={NoticeType.email}
-            noticeState={newNoticeState.email}
+            INoticeState={newNoticeState.email}
             setNewNoticeState={setNewNoticeState}
           />
         </Mantine.Tabs.Panel>
@@ -89,12 +89,12 @@ export default function NoticeTabs({
 }
 
 function NoticePanel(props: TabPanelProps) {
-  const { value, index, noticeState, setNewNoticeState, ...other } = props;
+  const { value, index, INoticeState, setNewNoticeState, ...other } = props;
   const t_AccountSettings = useTranslations("AccountSettings");
 
   const handleChange = (key: string, value: boolean) => {
     const newNoticeState = {
-      ...noticeState,
+      ...INoticeState,
       [key]: value,
     };
     setNewNoticeState((prevState) => ({
@@ -116,23 +116,23 @@ function NoticePanel(props: TabPanelProps) {
         <>
           <Mantine.Switch
             label={t_AccountSettings("favorite")}
-            checked={noticeState.favorite}
-            onChange={() => handleChange("favorite", !noticeState.favorite)}
+            checked={INoticeState.favorite}
+            onChange={() => handleChange("favorite", !INoticeState.favorite)}
           />
           <Mantine.Switch
             label={t_AccountSettings("bookmark")}
-            checked={noticeState.bookmark}
-            onChange={() => handleChange("bookmark", !noticeState.bookmark)}
+            checked={INoticeState.bookmark}
+            onChange={() => handleChange("bookmark", !INoticeState.bookmark)}
           />
           <Mantine.Switch
             label={t_AccountSettings("comment")}
-            checked={noticeState.comment}
-            onChange={() => handleChange("comment", !noticeState.comment)}
+            checked={INoticeState.comment}
+            onChange={() => handleChange("comment", !INoticeState.comment)}
           />
           <Mantine.Switch
             label={t_AccountSettings("follower")}
-            checked={noticeState.follower}
-            onChange={() => handleChange("follower", !noticeState.follower)}
+            checked={INoticeState.follower}
+            onChange={() => handleChange("follower", !INoticeState.follower)}
           />
         </>
       )}

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -5,7 +5,7 @@ import * as MantineDropzone from "@mantine/dropzone";
 import { useTranslations } from "next-intl";
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import "@mantine/dropzone/styles.css";
-import { UserPageEdit } from "@/types";
+import { IUserPageEdit } from "@/types";
 import { useState } from "react";
 import { FaImage } from "rocketicons/fa";
 import { useForm } from "@mantine/form";
@@ -13,7 +13,7 @@ import { useForm } from "@mantine/form";
 export default function UserEdit({
   userProfile,
 }: {
-  userProfile: UserPageEdit;
+  userProfile: IUserPageEdit;
 }) {
   const t_General = useTranslations("General");
   const [opened, { open, close }] = useDisclosure(false);

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -1,4 +1,4 @@
-import { ButtonState, PublicState } from "@/types";
+import { IButtonState, IPublicState } from "@/types";
 import { BookmarkButton, FavoriteButton, ShareButton } from ".";
 import { RequiredLoginModal } from "../modal";
 
@@ -9,8 +9,8 @@ export function IconButtonList({
   publicState,
 }: {
   postId: number;
-  buttonState: ButtonState;
-  publicState: PublicState;
+  buttonState: IButtonState;
+  publicState: IPublicState;
 }) {
   const currentUser = true; // TODO : ログインユーザーの状態
 
@@ -25,7 +25,7 @@ export function IconButtonList({
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState.valueOf() === PublicState.All && (
+          {publicState.valueOf() === IPublicState.All && (
             <li className="mx-2 h-full text-center">
               <ShareButton />
             </li>
@@ -44,8 +44,8 @@ export function FixedIconButtonList({
   publicState,
 }: {
   postId: number;
-  buttonState: ButtonState;
-  publicState: PublicState;
+  buttonState: IButtonState;
+  publicState: IPublicState;
 }) {
   const currentUser = true; // TODO : ログインユーザーの状態
 
@@ -60,7 +60,7 @@ export function FixedIconButtonList({
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState.valueOf() === PublicState.Private && (
+          {publicState.valueOf() === IPublicState.Private && (
             <li className="h-full mx-2 text-center">
               <ShareButton />
             </li>

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -10,7 +10,7 @@ export interface IndexIllustData {
   count: number;
 }
 
-export interface ButtonState {
+export interface IButtonState {
   favorite: boolean;
   bookmark: boolean;
 }
@@ -23,19 +23,19 @@ export interface IUser {
   follower_count: number;
 }
 
-export interface NoticeState {
+export interface INoticeState {
   favorite: boolean;
   bookmark: boolean;
   comment: boolean;
   follower: boolean;
 }
 
-export interface NoticeStates {
-  app: NoticeState;
-  email: NoticeState;
+export interface INoticeStates {
+  app: INoticeState;
+  email: INoticeState;
 }
 
-export interface UserPageEdit {
+export interface IUserPageEdit {
   headerImage: string;
   avatar: string;
   link: {
@@ -48,10 +48,10 @@ export interface UserPageEdit {
   profile: string;
 }
 
-export enum PublicState {
-  Draft = "Draft",
-  All = "All",
-  URL = "URL",
-  Follower = "Follower",
-  Private = "Private",
+export enum IPublicState {
+  Draft = "draft",
+  All = "all_publish",
+  URL = "only_url",
+  Follower = "only_follower",
+  Private = "private_publish",
 }


### PR DESCRIPTION
# 概要
フロントで入力したデータをバックに送信しDB保存する実装をしました。

## 実装項目
- [x] 投稿したデータでDBが更新されること
- [x] 投稿に成功したらモーダルが表示されること
   - [x] 下書きであれば下書きモーダルが表示されること
   - [x] 投稿であれば投稿モーダルが表示されること
- [x] 投稿に失敗したら理由が表示されること

## 挙動
下書き保存の様子
[![Image from Gyazo](https://i.gyazo.com/26ade233761e44113762c5487e6045c5.gif)](https://gyazo.com/26ade233761e44113762c5487e6045c5)
コンソールにデータがあることを確認
[![Image from Gyazo](https://i.gyazo.com/13ed5f27d07dae33079e4dd174dc89ef.png)](https://gyazo.com/13ed5f27d07dae33079e4dd174dc89ef)

## 備考
コンポーネントの中身が増えてきたので、リファクタリングで切り分ける必要があるかもしれません。