### PR TITLE
【feature】バックの投稿データの編集処理 close #66

### DIFF
--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -10,4 +10,20 @@
 class Illust < ApplicationRecord
   has_one :post, as: :postable, dependent: :destroy
   has_one_attached :image
+
+  def active_storage_upload!(image)
+    data = image
+    # 送信されるデータは data: から始まるためエンコードデータのみ抽出
+    base64_data = data.split(",")[1]
+    decoded_image = Base64.decode64(base64_data)
+    # MiniMagickでwebpに軽量化
+    image = MiniMagick::Image.read(decoded_image)
+    image.format 'webp'
+
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(image.to_blob),
+      filename: SecureRandom.uuid,
+      content_type: 'image/webp'
+    )
+  end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -22,8 +22,34 @@ class Post < ApplicationRecord
   validates :caption, length: { maximum: 10_000 }
   enum publish_state: { draft: 0, all_publish: 1, only_url: 2, only_follower: 3, private_publish:4 }
 
+  def initialize_postable(type)
+    case type
+    when 'Illust'
+      Illust
+    end
+  end
+
   # 投稿タイプがイラストか
   def illust?
     postable.is_a?(Illust)
+  end
+
+  # 投稿のメインコンテンツの更新可能か
+  def main_content_updatable?
+    if illust?
+      # イラストは未公開時のみ変更可能
+      # 公開日時がなければ未公開なので更新可能
+      published_at.nil?
+    else
+      # イラスト以外は更新可能
+      true
+    end
+  end
+
+  # 初公開なら公開日を設定
+  def set_published_at(publish_state=nil)
+    if publish_state != 'draft' && self.published_at.nil?
+      self.published_at = Time.now
+    end
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
-      resources :posts, only: %i[create]
+      resources :posts, only: %i[create update]
     end
   end
 end

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -109,10 +109,7 @@ export default function IllustPostPage() {
   };
 
   const handleModalClose = () => {
-    if (
-      errorMessage === "" &&
-      form.values.publishRange !== IPublicState.Draft
-    ) {
+    if (errorMessage === "") {
       router.push(RouterPath.users(user.id));
     }
     setModalOpen(false);


### PR DESCRIPTION
# 概要
投稿データの編集処理のバックを実装しました。
Postmanで確認しています。

## 実装項目
- [x] タイトルを変更できること
- [x] キャプションを変更できること
- [ ] タグを変更できること
   - [ ] タグが削除されたら削除すること
   - [ ] 新しいタグが追加されたら追加すること
   ⇨ #72 で対応
- [ ] システムを変更できること
   ⇨ #74 で対応
- [ ] シナリオ名を変更できること
   ⇨ #73 で対応
- [x] 公開範囲を変更できること
- [ ] 非公開含め一度も公開していなければ下書き保存ができること
   ⇨非公開は公開したとみなすことに変更（下書き保存はあっても初手で非公開投稿は考えにくいため）
- [ ] 一度でも公開していたら下書き保存できないこと
   ⇨フロントで実装しているので一旦なし
- [x] 下書き保存のときのみ、イラストも変更できること
   - [ ] イラストが削除されていたらイラストを削除する
   - [ ] イラストが追加されていたらイラストを追加する
   - [ ] イラストの順番が変わっていたら変更する
   ⇨イラストの差し替えは「削除」から「追加」の仕様。
   ⇨イラストがない状態での保存をさせないようにする方向に変更（投稿しようというタイミングで使うと考えると、イラストがない状態での下書き保存は考えにくいため）

## 補足
MVPへ色々盛り込みすぎて期日に間に合わない可能性もあるので、適宜ハードルを下げて実装しています。

## 挙動
動作確認はPostmanとターミナル上から確認しています
| 変更前 | 変更後 |
| --- | --- |
| <img src="https://i.gyazo.com/7a5a19426a9c36384fa591f8acc5ed6e.png" width="400px" /> | <img src="https://i.gyazo.com/f33302c1ed0078361dd0cd0927b87b37.png" width="400px" /> |