### PR TITLE
【feature】バックの投稿の削除処理 close #68

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,7 +1,7 @@
 require 'mini_magick'
 
 class Api::V1::PostsController < Api::V1::BasesController
-  before_action :set_post, only: %i[update]
+  before_action :set_post, only: %i[update destroy]
 
   def create
     default_params = post_params.except(:postable_attributes, :tags, :synalios)
@@ -30,8 +30,7 @@ class Api::V1::PostsController < Api::V1::BasesController
       post.save!
 
       render json: { id: post.id }, status: :created
-    rescue => e
-      logger.error(e)
+    rescue
       render json: { error: e.message }, status: :bad_request
     end
   end
@@ -79,9 +78,17 @@ class Api::V1::PostsController < Api::V1::BasesController
       @post.update!(post_params.except(:postable_attributes, :tags, :synalios))
 
       render json: { id: @post.id }, status: :ok
-    rescue => e
-      logger.error(e)
+    rescue
       render json: { error: e.message }, status: :bad_request
+    end
+  end
+
+  def destroy
+    begin
+      @post.destroy!
+      render json: { title: @post.title }, status: :ok
+    rescue
+      render json: { error: 'Not Found' }, status: :not_found
     end
   end
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
-      resources :posts, only: %i[create edit update]
+      resources :posts, only: %i[create edit update destroy]
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
     end


### PR DESCRIPTION
# 概要
投稿の削除処理を実装しました。バックエンドで確認済みです

## 実装項目
- [x] イラストが削除されること
- [x] タグの中間テーブルが削除されること
- [x] システムの中間テーブルが削除されること
- [x] シナリオの中間テーブルが削除されること
- [x] 投稿が削除されること
- [ ] 投稿につけられたコメントが削除されること
   ⇨ #59 で実装予定
- [ ] 投稿につけられたコメントの中間テーブルが削除されること
   ⇨ #59 で実装予定

## 挙動
<img src="https://i.gyazo.com/8905a48650b64de72916880639575696.png" width="500px" />

①左ターミナルで`Post.all`をしたとき、id15とid16のデータが有ることがわかります
②Postmanからidを指定してdeleteリクエストを飛ばすと、削除した投稿タイトルが返却されます
③左ターミナル下側で、`Post.all`をするとid16から始まっており、id15がなくなっていることがわかります