### PR TITLE
【feature】削除ボタンを押したら削除 close #69

### DIFF
--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TransitionsModal } from "@/components/ui";
-import { GetFromAPI, Put2API, useRouter } from "@/lib";
+import { Delete2API, GetFromAPI, Put2API, useRouter } from "@/lib";
 import { modalOpenState, userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
 import { IEditIllustData, IPublicState } from "@/types";
@@ -166,9 +166,21 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
     setIsDelete(true);
   };
 
-  const handleDeleteSubmit = () => {
+  const handleDeleteSubmit = async () => {
     if (!isDeleteConfirmation) {
       setDeleteConfirmationError(t_EditGeneral("checkDeleteValid"));
+      return;
+    }
+
+    try {
+      const res = await Delete2API(`/posts/${id}`);
+      if (res.status != 200) {
+        setErrorMessage(t_EditGeneral("deleteError"));
+        return;
+      }
+      router.push(RouterPath.users(user.id));
+    } catch (e) {
+      setErrorMessage(t_EditGeneral("deleteError"));
       return;
     }
   };
@@ -421,7 +433,10 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                   size="md"
                   radius="xl"
                   color="red"
-                  onChange={() => setIsDeleteConfirmation(!isDelete)}
+                  checked={isDeleteConfirmation}
+                  onChange={(event) =>
+                    setIsDeleteConfirmation(event.currentTarget.checked)
+                  }
                 />
                 {deleteConfirmationError && (
                   <p className="text-red-400">{deleteConfirmationError}</p>


### PR DESCRIPTION
# 概要
フロントとバックで投稿データの削除を連携させました。

## 実装項目
- [x] 削除モーダルで削除ボタンを押したら削除処理が走ること
- [x] 削除されること
- [x] 削除に成功したらマイページへ遷移すること
- [x] 削除に失敗したら失敗した理由が表示されること

## 補足
削除後に削除の表示が出ないので別途実装の必要がありそうです。

## 挙動
<img src="https://i.gyazo.com/27bb69f7a1995669c74244785f7f0fa9.gif" width="500px" />

上手く表示されない場合は[こちら](https://i.gyazo.com/27bb69f7a1995669c74244785f7f0fa9.mp4)よりご覧いただけます