### PR TITLE
【feature】投稿データの詳細情報取得 close #56

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   before_action :set_post, only: %i[update destroy]
 
   def show
-    post = Post.includes(:postable, :tags, :synalios).find_by(id: params[:id])
+    post = Post.includes(:postable, :tags, :synalios, :user).find_by(id: params[:id])
 
     if post.nil? || !post.publishable?(current_api_v1_user)
       render json: { error: 'Not Found' }, status: :not_found and return
@@ -16,7 +16,7 @@ class Api::V1::PostsController < Api::V1::BasesController
       content = post.postable.image.attached? ? url_for(post.postable.image) : nil
     end
 
-    render json: post.as_custom_json(content), status: :ok
+    render json: post.as_custom_show_json(content), status: :ok
   end
 
   def create
@@ -63,7 +63,7 @@ class Api::V1::PostsController < Api::V1::BasesController
       content = post.postable.image.attached? ? url_for(post.postable.image) : nil
     end
 
-    render json: post.as_custom_json(content), status: :ok
+    render json: post.as_custom_edit_json(content), status: :ok
   end
 
   def update

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,7 +1,23 @@
 require 'mini_magick'
 
 class Api::V1::PostsController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[show]
   before_action :set_post, only: %i[update destroy]
+
+  def show
+    post = Post.includes(:postable, :tags, :synalios).find_by(id: params[:id])
+
+    if post.nil? || !post.publishable?(current_api_v1_user)
+      render json: { error: 'Not Found' }, status: :not_found and return
+    end
+
+    content = nil
+    if post.illust?
+      content = post.postable.image.attached? ? url_for(post.postable.image) : nil
+    end
+
+    render json: post.as_custom_json(content), status: :ok
+  end
 
   def create
     default_params = post_params.except(:postable_attributes, :tags, :synalios)
@@ -36,7 +52,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   end
 
   def edit
-    post = current_api_v1_user.posts.includes(:postable,:tags, :synalios).find_by(id: params[:id])
+    post = current_api_v1_user.posts.includes(:postable, :tags, :synalios).find_by(id: params[:id])
 
     if post.nil?
       render json: { error: 'Not Found' }, status: :not_found and return
@@ -47,7 +63,7 @@ class Api::V1::PostsController < Api::V1::BasesController
       content = post.postable.image.attached? ? url_for(post.postable.image) : nil
     end
 
-    render json: post.as_custom_edit_json(content), status: :ok
+    render json: post.as_custom_json(content), status: :ok
   end
 
   def update

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -111,8 +111,27 @@ class Post < ApplicationRecord
     end
   end
 
+  # 表示用のカスタムjson
+  def as_custom_show_json(content)
+    {
+      id: id,
+      title: title,
+      caption: caption,
+      synalio: synalios.map(&:name).first,
+      tags: tags.map(&:name),
+      data: [content],
+      user: {
+        id: user.id,
+        name: user.name,
+        profile: user.profile&.text,
+        avatar: user.profile&.avatar&.url,
+        follower: user.followers.count
+      }
+    }
+  end
+
   # 編集用のカスタムjson
-  def as_custom_json(content)
+  def as_custom_edit_json(content)
     {
       id: id,
       title: title,

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -27,6 +27,24 @@ class Post < ApplicationRecord
   validates :caption, length: { maximum: 10_000 }
   enum publish_state: { draft: 0, all_publish: 1, only_url: 2, only_follower: 3, private_publish:4 }
 
+  # 公開可能か
+  def publishable?(current_user=nil)
+    case publish_state
+    when 'draft'
+      current_user == user
+    when 'all_publish'
+      true
+    when 'only_url'
+      true
+    when 'only_follower'
+      self.user.followers.include?(current_user)
+    when 'private_publish'
+      current_user == user
+    else
+      false
+    end
+  end
+
   # タグの作成
   def create_tags(new_tags)
     new_tags.each do |tag|
@@ -94,7 +112,7 @@ class Post < ApplicationRecord
   end
 
   # 編集用のカスタムjson
-  def as_custom_edit_json(content)
+  def as_custom_json(content)
     {
       id: id,
       title: title,

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
-      resources :posts, only: %i[create edit update destroy]
+      resources :posts, only: %i[show create edit update destroy]
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
     end


### PR DESCRIPTION
# 概要
投稿データの詳細情報を取得する実装をバックエンドのみしました。

## 実装項目
- [x] イラストの下部情報が取得できること
   - [x] 作品名
   - [x] キャプション
   - [ ] タグ
   - [ ] いいね（ログインでのみ操作可能）
   ⇨ #58  にて実装
   - [ ] ブックマーク（ログインでのみ操作可能）
   ⇨ #146 にて実装
- [ ] いいね数とブックマーク数は投稿ユーザーのみ取得できること
   ⇨ #58  #146 にて実装
- [ ] 作者情報として以下の情報が取得できること
   - [x] ユーザー名
   - [x] ユーザーアイコン
   - [ ] フォローボタン/フォロー解除ボタン
   ⇨ #148 にて実装
   - [x] プロフィールテキスト
   - [ ] リンク集
   ⇨ #147 にて実装
   - [x] フォロー人数
   - [x] フォロワー人数

## 補足
下記項目は #59  にて実装します
- [ ] コメントとして下記情報が取得できること
   - [ ] ユーザー名
   - [ ] ユーザーアイコン
   - [ ] ユーザーのコメント
   - [ ] コメントは新着5件のみ
   - [ ] コメントの新着6件目以降のみ

## 挙動
<img src="https://i.gyazo.com/2ff378f9c1304eef21460d40d9384f00.png" width="500px" />