### PR TITLE
【feature】イラスト詳細ページをバックと連携・リンク不具合修正 close #57 #118

### DIFF
--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -126,7 +126,8 @@ class Post < ApplicationRecord
         profile: user.profile&.text,
         avatar: user.profile&.avatar&.url,
         follower: user.followers.count
-      }
+      },
+      published_at: published_at.strftime('%Y/%m/%d %H:%M:%S')
     }
   end
 

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -85,7 +85,9 @@
     "follow": "フォロー",
     "unFollow": "フォロー解除",
     "send": "送信",
-    "requiredComment": "コメント機能はログインで使えます"
+    "requiredComment": "コメント機能はログインで使えます",
+    "fusetter": "ふせったー",
+    "other": "その他"
   },
   "AccountSettings": {
     "settings": "設定",

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function IllustPage({
               >
                 <Mantine.Image
                   src={illustData.data[0]}
-                  alt="拡大表示"
+                  alt={illustData.title}
                   fit="contain"
                   style={{
                     maxHeight: "80vh",
@@ -221,7 +221,7 @@ export default function IllustPage({
                 </div>
               </form>
               <div className="w-full h-full absolute top-0 left-0 bg-gray-500 bg-opacity-80 text-white font-semibold md:text-3xl flex justify-center items-center rounded">
-                <p>コメント機能はログインで使えます</p>
+                <p>{t_ShowPost("requiredComment")}</p>
               </div>
             </section>
 
@@ -260,7 +260,7 @@ export default function IllustPage({
 
         <article className="hidden md:w-1/3 md:block md:sticky md:top-4">
           <section className="bg-white p-4 rounded flex flex-col gap-4">
-            <h3 className="text-xl">投稿者</h3>
+            <h3 className="text-xl">{t_ShowPost("postUser")}</h3>
             <div className="flex gap-4 justify-start items-center">
               <Link href="/users/1">
                 <Mantine.Avatar
@@ -279,7 +279,7 @@ export default function IllustPage({
                     onClick={handleFollow}
                     className="w-32"
                   >
-                    フォロー解除
+                    {t_ShowPost("unFollow")}
                   </Mantine.Button>
                 ) : (
                   <Mantine.Button
@@ -288,7 +288,7 @@ export default function IllustPage({
                     onClick={handleFollow}
                     className="w-32"
                   >
-                    フォロー
+                    {t_ShowPost("follow")}
                   </Mantine.Button>
                 )}
               </div>
@@ -304,10 +304,10 @@ export default function IllustPage({
                 privatter
               </Link>
               <Link href="" className="bg-slate-300 rounded px-2">
-                ふせったー
+                {t_ShowPost("fusetter")}
               </Link>
               <Link href="" className="bg-slate-300 rounded px-2">
-                HP
+                {t_ShowPost("other")}
               </Link>
             </div>
             <div>

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -135,7 +135,7 @@ export default function IllustPage({
                   </Mantine.Button>
                   <div className="text-sm flex justify-center items-center md:justify-start gap-2">
                     <Link
-                      href="/illusts/search=1"
+                      href="/illusts?search=1"
                       className="bg-blue-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                     >
                       システム名

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -108,7 +108,7 @@ export default function IllustPage({
                   <IconButtonList
                     postId={id}
                     buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-                    publicState={IPublicState.All} // TODO : 投稿の公開範囲
+                    publicState={illustData.publish_state}
                   />
                   <h3 className="text-2xl font-semibold">{illustData.title}</h3>
                   <Mantine.Button

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -3,14 +3,14 @@
 import { FormEvent, useState } from "react";
 import { useSetRecoilState } from "recoil";
 import * as RecoilState from "@/recoilState";
-import { GetFromAPI, Link } from "@/lib";
+import { GetFromAPI, Link, useRouter } from "@/lib";
 import * as Mantine from "@mantine/core";
 import { FixedIconButtonList, IconButtonList } from "@/components/ui";
 import { useTranslations } from "next-intl";
 import { useMediaQuery } from "@mantine/hooks";
 import { MdCollections } from "rocketicons/md";
-import { IPublicState } from "@/types";
 import useSWR from "swr";
+import { RouterPath } from "@/settings";
 
 const fetcherIllust = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -31,9 +31,15 @@ export default function IllustPage({
   const theme = Mantine.useMantineTheme();
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
   const CAPTION_OPEN_LENGTH = 280;
+  const router = useRouter();
 
   if (illustError) return <div>error</div>;
   if (!illustData) return <div>now loading...</div>;
+
+  if (illustData.error === "Not Found") {
+    // TODO : 404ページへリダイレクト
+    router.push(RouterPath.home);
+  }
 
   const handleOpenUser = () => {
     // TODO : 投稿者の情報モーダルの表示

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -135,13 +135,13 @@ export default function IllustPage({
                   </Mantine.Button>
                   <div className="text-sm flex justify-center items-center md:justify-start gap-2">
                     <Link
-                      href="/illusts/gameSystem=1"
+                      href="/illusts/search=1"
                       className="bg-blue-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                     >
                       システム名
                     </Link>
                     <Link
-                      href={`/illusts?scenario=${illustData.synalio}`}
+                      href={`/illusts?search=${illustData.synalio}`}
                       className="bg-green-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                     >
                       {illustData.synalio}
@@ -151,7 +151,7 @@ export default function IllustPage({
                     {illustData.tags.map((tag: string, i: number) => (
                       <Link
                         key={i}
-                        href={`/illusts?tag=${tag}`}
+                        href={`/illusts?search=${tag}`}
                         className="text-blue-600 hover:underline hover:opacity-60 transition-all"
                       >
                         #{tag}

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -196,8 +196,11 @@ export default function IllustPage({
               <form onSubmit={handleSendComment}>
                 <div className="flex items-start gap-4">
                   <Mantine.Avatar
+                    variant="default"
+                    radius="xl"
+                    size="md"
                     alt="icon"
-                    src="https://placehold.jp/300x300.png"
+                    src={illustData.user.avatar}
                   />
                   <div className="flex flex-col gap-2 w-full">
                     <span className="p-0 m-0 font-semibold">ユーザー名</span>
@@ -233,10 +236,7 @@ export default function IllustPage({
                     className="flex gap-4 items-start py-4 border-b border-slate-200 last-of-type:border-none"
                   >
                     <Link href="/users/1">
-                      <Mantine.Avatar
-                        alt="icon"
-                        src="https://placehold.jp/300x300.png"
-                      />
+                      <Mantine.Avatar alt="icon" src={illustData.user.avatar} />
                     </Link>
                     <div className="flex flex-col gap-1">
                       <Link href="/users/1" className="font-semibold">
@@ -264,8 +264,11 @@ export default function IllustPage({
             <div className="flex gap-4 justify-start items-center">
               <Link href="/users/1">
                 <Mantine.Avatar
+                  variant="default"
+                  radius="xl"
+                  size="lg"
                   alt="icon"
-                  src="https://placehold.jp/300x300.png"
+                  src={illustData.user.avatar}
                 />
               </Link>
               <div className="w-full flex flex-col gap-2">
@@ -320,7 +323,7 @@ export default function IllustPage({
       <FixedIconButtonList
         postId={id}
         buttonState={{ favorite: false, bookmark: false }} // TODO : いいね・ブックマークの状態
-        publicState={IPublicState.All} // TODO : 投稿の公開範囲
+        publicState={illustData.publish_state}
       />
     </article>
   );

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -56,7 +56,7 @@ export function FixedIconButtonList({
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState.valueOf() === IPublicState.Private && (
+          {publicState === IPublicState.All && (
             <li className="h-full mx-2 text-center">
               <ShareButton />
             </li>

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -12,8 +12,6 @@ export function IconButtonList({
   buttonState: IButtonState;
   publicState: IPublicState;
 }) {
-  const currentUser = true; // TODO : ログインユーザーの状態
-
   return (
     <>
       <div className="hidden md:flex gap-2 justify-end items-center">
@@ -25,7 +23,7 @@ export function IconButtonList({
             <BookmarkButton state={buttonState.bookmark} />
           </li>
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState.valueOf() === IPublicState.All && (
+          {publicState === IPublicState.All && (
             <li className="mx-2 h-full text-center">
               <ShareButton />
             </li>
@@ -47,8 +45,6 @@ export function FixedIconButtonList({
   buttonState: IButtonState;
   publicState: IPublicState;
 }) {
-  const currentUser = true; // TODO : ログインユーザーの状態
-
   return (
     <>
       <article className="fixed bottom-0 left-0 w-full md:hidden">

--- a/front/src/components/ui/iconsButton/index.tsx
+++ b/front/src/components/ui/iconsButton/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as RecoilState from "@/recoilState";
 import { IconButtonList, FixedIconButtonList } from "./iconButtonList";
 import { MdFavorite, MdOutlineFavoriteBorder, MdShare } from "rocketicons/md";
@@ -9,13 +9,15 @@ import { FaBookmark, FaRegBookmark } from "rocketicons/fa";
 import { Button } from "@mantine/core";
 
 const FavoriteButton = ({ state }: { state: boolean }) => {
+  const user = useRecoilValue(RecoilState.userState);
   const [favorite, setFavorite] = useState(state);
   const setModalOpen = useSetRecoilState(RecoilState.requireModalOpenState);
 
   const handleFavorite = (value: boolean) => {
-    // TODO : ログインユーザーでなければログインや登録を促す
-    setModalOpen(true);
-    return;
+    if (!user) {
+      setModalOpen(true);
+      return;
+    }
 
     // TODO : いいねの更新処理
     setFavorite(!favorite);
@@ -28,6 +30,7 @@ const FavoriteButton = ({ state }: { state: boolean }) => {
           onClick={() => handleFavorite(false)}
           variant="transparent"
           color="pink"
+          className="p-0"
         >
           <MdFavorite className="icon-red-400" />
         </Button>
@@ -45,13 +48,15 @@ const FavoriteButton = ({ state }: { state: boolean }) => {
 };
 
 const BookmarkButton = ({ state }: { state: boolean }) => {
+  const user = useRecoilValue(RecoilState.userState);
   const [bookmark, setBookmark] = useState(state);
   const setModalOpen = useSetRecoilState(RecoilState.requireModalOpenState);
 
   const handleBookmark = (value: boolean) => {
-    // TODO : ログインユーザーでなければログインや登録を促す
-    setModalOpen(true);
-    return;
+    if (!user) {
+      setModalOpen(true);
+      return;
+    }
 
     // TODO : ブックマークの更新処理
     setBookmark(!bookmark);
@@ -60,14 +65,17 @@ const BookmarkButton = ({ state }: { state: boolean }) => {
   return (
     <>
       {bookmark ? (
-        <Button onClick={() => handleBookmark(false)} variant="transparent">
+        <Button
+          onClick={() => handleBookmark(false)}
+          variant="transparent"
+          className="p-0"
+        >
           <FaBookmark className="icon-sky-500" />
         </Button>
       ) : (
         <Button
           onClick={() => handleBookmark(true)}
           variant="transparent"
-          color="gray"
           className="p-0"
         >
           <FaRegBookmark className="icon-gray-500" />


### PR DESCRIPTION
# 概要
投稿したイラストの詳細ページをフロントとバックで連携して実装しました。

## 実装項目
- [ ] 取得したデータを表示できること
   - [x] イラスト
   - [x] 作品名
   - [x] キャプション
   - [x] タグ
   - [x] いいね
   - [ ] ログインユーザーと一致すればいいね数
   ⇨ #58 にて実装
   - [ ] ブックマーク
   ⇨ #146  にて実装
   - [ ] ログインユーザーと一致すればブックマーク数 
   ⇨ #146  にて実装
   - [x] ユーザー名
   - [x] ユーザーアイコン
   - [ ] フォロワー数
   ⇨このページでは不要と判断、 #92 にて
   - [x] プロフィールテキスト
   - [ ] リンク集
   ⇨ #147 にて

## 補足
#118 も合わせて修正しました
下記項目は #60 にて実装予定です。
- [ ] コメント一覧の新着5件
- [ ] コメントしたユーザー名
- [ ] コメントしたユーザーアイコン
- [ ] コメント内容

## 挙動
<img src="https://i.gyazo.com/bf705f75e26fe668ac16788a9b310b3d.gif" width="500px" />

正常に表示されないときは[こちら](https://i.gyazo.com/bf705f75e26fe668ac16788a9b310b3d.mp4)からご覧いただけます