### PR TITLE
【feature】未検索時の投稿一覧取得（バック） close #47

### DIFF
--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -138,6 +138,20 @@ class Post < ApplicationRecord
     end
   end
 
+  # 未検索時用のカスタムjson
+  def as_custom_index_json(content)
+    {
+      id: id,
+      title: title,
+      data: [content],
+      user: {
+        id: user.id,
+        name: user.name,
+        avatar: user.profile&.avatar&.url,
+      }
+    }
+  end
+
   # 表示用のカスタムjson
   def as_custom_show_json(content)
     {

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
-      resources :posts, only: %i[show create edit update destroy]
+      resources :posts, only: %i[index show create edit update destroy]
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
       resources :game_systems, only: %i[index]


### PR DESCRIPTION
# 概要
未検索時における投稿一覧を取得する実装をしました。

## 実装項目
- [x] 全ユーザーのイラストを新着順に取得できること（20件くらい？）
   - [x] イラストid（リンクのためのスラッグ）
   - [x] ユーザー名
   - [x] ユーザーアイコン
   - [x] ユーザーid（リンクのためのスラッグ）
   - [x] 全体公開のみ
   - [ ] フォローしているユーザーは除く
   ⇨後述

## フォローしている人の新着順について
下記実装項目についてです
- [ ] フォローのイラストを新着順に取得できること（20件くらい？）
   - [ ] イラストid（リンクのためのスラッグ）
   - [ ] ユーザー名
   - [ ] ユーザーアイコン
   - [ ] ユーザーid（リンクのためのスラッグ）
- [ ] 全ユーザーのイラストを新着順に取得できること（20件くらい？）
   - [ ] フォローしているユーザーは除く

サービス開始時は投稿数が少ないことからフォローの新着順は入れず、全体の新着順を表示します。

## 挙動
Postmanから確認しています。
<img src="https://i.gyazo.com/731e31e8c80f0f42587584799c7aad6e.png" width="500px" />