### PR TITLE
【feature】未検索時（ホーム）での投稿一覧表示 close #48

### DIFF
--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -4,7 +4,7 @@ const withNextIntl = createNextIntlPlugin();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['placehold.jp', 'aceternity.com'], // ダミー画像のURLを許可
+    domains: ['placehold.jp'], // ダミー画像のURLを許可
   }
 };
 

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -4,7 +4,7 @@ const withNextIntl = createNextIntlPlugin();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['placehold.jp'], // ダミー画像のURLを許可
+    domains: ['placehold.jp', 'aceternity.com'], // ダミー画像のURLを許可
   }
 };
 

--- a/front/package.json
+++ b/front/package.json
@@ -20,15 +20,17 @@
     "@mantine/notifications": "^7.8.1",
     "@mantine/spotlight": "^7.8.1",
     "axios": "^1.6.8",
+    "clsx": "^2.1.1",
     "embla-carousel-react": "^8.0.2",
-    "framer-motion": "^11.1.9",
+    "framer-motion": "^11.2.4",
     "next": "14.2.1",
     "next-intl": "^3.11.1",
     "react": "^18",
     "react-dom": "^18",
     "recoil": "^0.7.7",
     "rocketicons": "^0.2.1-alpha",
-    "swr": "^2.2.5"
+    "swr": "^2.2.5",
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/front/src/app/[locale]/page.tsx
+++ b/front/src/app/[locale]/page.tsx
@@ -1,39 +1,37 @@
-import { IllustCarousel } from "@/components/features/illusts";
-import { useTranslations } from "next-intl";
+"use client";
+import React from "react";
+import { HomeParallax } from "@/components/features/home";
+import { GetFromAPI } from "@/lib";
+import useSWR from "swr";
 
-// 仮データをハードコーディング
-const illusts = Array.from({ length: 10 }).map((_, i) => ({
-  id: i,
-  image: "/assets/900x1600.png",
-  title: `イラスト${i}`,
-  user: {
-    id: i,
-    name: `ユーザー${i}`,
-    avatar: "/assets/900x1600.png",
-  },
-  count: Math.floor(Math.random() * 2) + 1,
-}));
+const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function Home() {
-  const t_General = useTranslations("General");
-  return (
-    <div className="w-full flex flex-col gap-16 my-8">
-      <article>
-        <h2 className="text-xl text-start my-4 ml-8">
-          {t_General("followedNewPosts")}
-        </h2>
-        <section>
-          <IllustCarousel illustsData={illusts} />
-        </section>
-      </article>
-      <article>
-        <h2 className="text-xl text-start mb-4 ml-8">
-          {t_General("newPosts")}
-        </h2>
-        <div>
-          <IllustCarousel illustsData={illusts} />
-        </div>
-      </article>
-    </div>
+  const { data, error } = useSWR("/posts", fetcher);
+  if (error) return <div>error</div>;
+  if (!data) return <div>loading...</div>;
+
+  const illusts = data.map(
+    (illust: {
+      id: number;
+      title: string;
+      data: string[];
+      user: {
+        id: number;
+        name: string;
+        avatar: string;
+      };
+    }) => ({
+      id: illust.id,
+      title: illust.title,
+      image: illust.data[0],
+      user: {
+        id: illust.user.id,
+        name: illust.user.name,
+        avatar: illust.user.avatar,
+      },
+    })
   );
+
+  return <HomeParallax illusts={illusts} />;
 }

--- a/front/src/components/features/home/homeParallax.tsx
+++ b/front/src/components/features/home/homeParallax.tsx
@@ -16,6 +16,7 @@ export const HomeParallax = ({ illusts }: { illusts: IHomeIllustData[] }) => {
   const firstRow = illusts.slice(0, 5);
   const secondRow = illusts.slice(5, 10);
   const thirdRow = illusts.slice(10, 15);
+  const fourRow = illusts.slice(15, 20);
   const ref = React.useRef(null);
   const { scrollYProgress } = useScroll({
     target: ref,
@@ -65,37 +66,37 @@ export const HomeParallax = ({ illusts }: { illusts: IHomeIllustData[] }) => {
       >
         <motion.div className="flex flex-row-reverse space-x-reverse space-x-6 md:space-x-20 mb-5 md:mb-20">
           {firstRow.map((illust) => (
-            <ProductCard
+            <IllustCard
               illust={illust}
               translate={translateX}
-              key={illust.title}
+              key={illust.id}
             />
           ))}
         </motion.div>
         <motion.div className="flex flex-row space-x-6 md:space-x-20 mb-5 md:mb-20">
           {secondRow.map((illust) => (
-            <ProductCard
+            <IllustCard
               illust={illust}
               translate={translateXReverse}
-              key={illust.title}
+              key={illust.id}
             />
           ))}
         </motion.div>
         <motion.div className="flex flex-row-reverse space-x-reverse space-x-6 md:space-x-20 mb-5 md:mb-20">
           {thirdRow.map((illust) => (
-            <ProductCard
+            <IllustCard
               illust={illust}
               translate={translateX}
-              key={illust.title}
+              key={illust.id}
             />
           ))}
         </motion.div>
         <motion.div className="flex flex-row space-x-6 md:space-x-20">
-          {secondRow.map((illust) => (
-            <ProductCard
+          {fourRow.map((illust) => (
+            <IllustCard
               illust={illust}
               translate={translateXReverse}
-              key={illust.title}
+              key={illust.id}
             />
           ))}
         </motion.div>
@@ -105,6 +106,7 @@ export const HomeParallax = ({ illusts }: { illusts: IHomeIllustData[] }) => {
 };
 
 export const Header = () => {
+  // TODO : ロゴアイコンを入れたい
   return (
     <div className="max-w-7xl relative mx-auto py-20 md:py-40 px-4 w-full  left-0 top-0">
       <h1 className="text-2xl md:text-7xl font-bold">
@@ -116,7 +118,7 @@ export const Header = () => {
   );
 };
 
-export const ProductCard = ({
+export const IllustCard = ({
   illust,
   translate,
 }: {

--- a/front/src/components/features/home/homeParallax.tsx
+++ b/front/src/components/features/home/homeParallax.tsx
@@ -1,0 +1,170 @@
+"use client";
+import React from "react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useSpring,
+  MotionValue,
+} from "framer-motion";
+import * as Mantine from "@mantine/core";
+import { Link } from "@/lib";
+import { RouterPath } from "@/settings";
+import { IHomeIllustData } from "@/types";
+
+export const HomeParallax = ({ illusts }: { illusts: IHomeIllustData[] }) => {
+  const firstRow = illusts.slice(0, 5);
+  const secondRow = illusts.slice(5, 10);
+  const thirdRow = illusts.slice(10, 15);
+  const ref = React.useRef(null);
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"],
+  });
+
+  const springConfig = { stiffness: 300, damping: 30, bounce: 100 };
+
+  const translateX = useSpring(
+    useTransform(scrollYProgress, [0, 1], [0, 1000]),
+    springConfig
+  );
+  const translateXReverse = useSpring(
+    useTransform(scrollYProgress, [0, 1], [0, -1000]),
+    springConfig
+  );
+  const rotateX = useSpring(
+    useTransform(scrollYProgress, [0, 0.2], [15, 0]),
+    springConfig
+  );
+  const opacity = useSpring(
+    useTransform(scrollYProgress, [0, 0.2], [0.2, 1]),
+    springConfig
+  );
+  const rotateZ = useSpring(
+    useTransform(scrollYProgress, [0, 0.2], [20, 0]),
+    springConfig
+  );
+  const translateY = useSpring(
+    useTransform(scrollYProgress, [0, 0.2], [-700, 500]),
+    springConfig
+  );
+  return (
+    <div
+      ref={ref}
+      className="h-[300vh] py-40 overflow-hidden  antialiased relative flex flex-col self-auto [perspective:1000px] [transform-style:preserve-3d]"
+    >
+      <Header />
+      <motion.div
+        style={{
+          rotateX,
+          rotateZ,
+          translateY,
+          opacity,
+        }}
+        className=""
+      >
+        <motion.div className="flex flex-row-reverse space-x-reverse space-x-6 md:space-x-20 mb-5 md:mb-20">
+          {firstRow.map((illust) => (
+            <ProductCard
+              illust={illust}
+              translate={translateX}
+              key={illust.title}
+            />
+          ))}
+        </motion.div>
+        <motion.div className="flex flex-row space-x-6 md:space-x-20 mb-5 md:mb-20">
+          {secondRow.map((illust) => (
+            <ProductCard
+              illust={illust}
+              translate={translateXReverse}
+              key={illust.title}
+            />
+          ))}
+        </motion.div>
+        <motion.div className="flex flex-row-reverse space-x-reverse space-x-6 md:space-x-20 mb-5 md:mb-20">
+          {thirdRow.map((illust) => (
+            <ProductCard
+              illust={illust}
+              translate={translateX}
+              key={illust.title}
+            />
+          ))}
+        </motion.div>
+        <motion.div className="flex flex-row space-x-6 md:space-x-20">
+          {secondRow.map((illust) => (
+            <ProductCard
+              illust={illust}
+              translate={translateXReverse}
+              key={illust.title}
+            />
+          ))}
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+};
+
+export const Header = () => {
+  return (
+    <div className="max-w-7xl relative mx-auto py-20 md:py-40 px-4 w-full  left-0 top-0">
+      <h1 className="text-2xl md:text-7xl font-bold">
+        AStoryer
+        <br />- あすとりや -
+      </h1>
+      <p className="max-w-2xl text-base md:text-xl mt-8">TRPG創作投稿サイト</p>
+    </div>
+  );
+};
+
+export const ProductCard = ({
+  illust,
+  translate,
+}: {
+  illust: IHomeIllustData;
+  translate: MotionValue<number>;
+}) => {
+  return (
+    <motion.div
+      style={{
+        x: translate,
+      }}
+      whileHover={{
+        y: -20,
+      }}
+      key={illust.title}
+      className="group/illust h-32 md:h-96 w-32 md:w-96 relative flex-shrink-0"
+    >
+      <Link
+        href={RouterPath.illust(illust.id)}
+        className="block group-hover/illust:shadow-2xl "
+      >
+        <Mantine.Image
+          src={illust.image}
+          height="600"
+          width="600"
+          className="object-cover object-left-top absolute h-full w-full inset-0"
+          alt={illust.title}
+        />
+      </Link>
+      <div className="absolute inset-0 h-full w-full opacity-0 group-hover/illust:opacity-80 bg-black pointer-events-none transition-all"></div>
+      <div className="absolute bottom-4 left-4 opacity-0 group-hover/illust:opacity-100 text-white transition-all">
+        <h2 className="text-xl my-3">{illust.title}</h2>
+        <div>
+          <Link
+            href={RouterPath.users(Number(illust.user.id))}
+            className="flex justify-start icon-outlined gap-2"
+          >
+            <Mantine.Avatar
+              variant="default"
+              radius="xl"
+              size="sm"
+              alt="icon"
+              src={illust.user.avatar}
+            />
+            <p>{illust.user.name}</p>
+          </Link>
+        </div>
+      </div>
+    </motion.div>
+  );
+};

--- a/front/src/components/features/home/index.ts
+++ b/front/src/components/features/home/index.ts
@@ -1,0 +1,3 @@
+import { HomeParallax } from "./homeParallax";
+
+export { HomeParallax };

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,3 +1,14 @@
+export interface IHomeIllustData {
+  id: number;
+  title: string;
+  image: string;
+  user: {
+    id: number;
+    name: string;
+    avatar: string;
+  };
+}
+
 export interface IndexIllustData {
   id: number;
   title: string;

--- a/front/src/utils/cn.ts
+++ b/front/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -54,7 +54,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.20.13":
+"@babel/runtime@^7.20.13", "@babel/runtime@^7.24.1":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
   integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
@@ -957,6 +957,11 @@ clsx@2.1.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
   integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1641,10 +1646,10 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-framer-motion@^11.1.9:
-  version "11.1.9"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.1.9.tgz#1ef021fc35615eb83d6baa903a47ba872be99187"
-  integrity sha512-flECDIPV4QDNcOrDafVFiIazp8X01HFpzc01eDKJsdNH/wrATcYydJSH9JbPWMS8UD5lZlw+J1sK8LG2kICgqw==
+framer-motion@^11.2.4:
+  version "11.2.4"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.2.4.tgz#d4e37071f12c1f2ac77673a179f9d24d0faad820"
+  integrity sha512-D+EXd0lspaZijv3BJhAcSsyGz+gnvoEdnf+QWkPZdhoFzbeX/2skrH9XSVFb0osgUnCajW8x1frjhLuKwa/Reg==
   dependencies:
     tslib "^2.4.0"
 
@@ -3129,6 +3134,13 @@ tabbable@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
+tailwind-merge@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.3.0.tgz#27d2134fd00a1f77eca22bcaafdd67055917d286"
+  integrity sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==
+  dependencies:
+    "@babel/runtime" "^7.24.1"
 
 tailwindcss@^3.4.1:
   version "3.4.3"


### PR DESCRIPTION
# 概要
未検索時であるホーム画面にて投稿一覧を表示する機能を実装しました。

## 実装項目
- [ ]  フォロイーの新着イラストが表示される
   ⇨サービス開始時は投稿数が少ないので表示しない
- [x] 全体の新着イラストが表示される

## 追加実装
framer-motionとtailwdinを利用したUIコンポーネントを導入しました。
[Aceternity UI](https://ui.aceternity.com/)の[Hero Parallax](https://ui.aceternity.com/components/hero-parallax)を取り入れています。

## 挙動
<img src="https://i.gyazo.com/6ea19125e3159e23acd21d1f2451881f.gif" width="400px" />

## 補足
レイアウト整えは #28 にて行うので未調整です。