### PR TITLE
【feature】ユーザーの投稿一覧とユーザー情報取得 close #30

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -11,18 +11,22 @@ class Api::V1::UsersController < Api::V1::BasesController
     posts = []
     # ログインユーザーと表示ユーザーが同じ場合は全ての投稿を取得
     if(current_api_v1_user && current_api_v1_user.id == user.id)
-      posts = user.posts
+      posts = user.posts.map do |post|
+        {
+          id: post.id,
+          data: url_for(post.postable.image),
+          publish_state: post.publish_state,
+        }
+      end
     else
       # ログインユーザーと表示ユーザーが異なる場合は公開投稿のみ取得
       # TODO : フォロワーの場合はフォロワー公開も取得
-      posts = user.posts.where(publish_state: 'all_publish')
-    end
-
-    posts = posts.map do |post|
-      {
-        id: post.id,
-        data: url_for(post.postable.image)
-      }
+      posts = user.posts.where(publish_state: 'all_publish').map do |post|
+        {
+          id: post.id,
+          data: url_for(post.postable.image),
+        }
+      end
     end
 
     render json: user.as_custom_json(posts), status: :ok

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,30 @@
+class Api::V1::UsersController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[show]
+
+  def show
+    user = User.find_by(id: params[:id])
+
+    if user.nil?
+      render json: { error: 'Not Found' }, status: :not_found and return
+    end
+
+    posts = []
+    # ログインユーザーと表示ユーザーが同じ場合は全ての投稿を取得
+    if(current_api_v1_user && current_api_v1_user.id == user.id)
+      posts = user.posts
+    else
+      # ログインユーザーと表示ユーザーが異なる場合は公開投稿のみ取得
+      # TODO : フォロワーの場合はフォロワー公開も取得
+      posts = user.posts.where(publish_state: 'all_publish')
+    end
+
+    posts = posts.map do |post|
+      {
+        id: post.id,
+        data: url_for(post.postable.image)
+      }
+    end
+
+    render json: user.as_custom_json(posts), status: :ok
+  end
+end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::UsersController < Api::V1::BasesController
       posts = user.posts.where(publish_state: 'all_publish').map do |post|
         {
           id: post.id,
-          data: url_for(post.postable.image),
+          data: post.illust? ? url_for(post.postable.image) : nil,
         }
       end
     end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -55,4 +55,16 @@ class User < ActiveRecord::Base
       follower_count: followers.count || 0,
     }
   end
+
+  def as_custom_json(posts = [])
+    {
+      id: id,
+      name: name,
+      avatar: profile&.avatar&.url,
+      header_image: profile&.header_image&.url,
+      following_count: following.count || 0,
+      follower_count: followers.count || 0,
+      posts: posts,
+    }
+  end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -62,6 +62,7 @@ class User < ActiveRecord::Base
       name: name,
       avatar: profile&.avatar&.url,
       header_image: profile&.header_image&.url,
+      profile: profile&.text,
       following_count: following.count || 0,
       follower_count: followers.count || 0,
       posts: posts,

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
       resources :game_systems, only: %i[index]
+      resources :users, only: %i[show]
     end
   end
 end


### PR DESCRIPTION
# 概要
ユーザーページで表示する、ユーザー情報とユーザーの投稿データを取得するバックエンドの処理を実装しました。

## 実装項目
全体共通
- [x] ユーザーアイコンを取得できること
- [x] ヘッダー画像を取得できること
- [x] ユーザー名を取得できること
- [x] ユーザープロフィールを取得できること
- [ ] ユーザーのリンク集を取得できること
   ⇨ #147 にて実装

ログインユーザーとページのユーザーが一致するとき
- [x] そのユーザーが投稿したイラストの全件を取得できること
- [ ] イラストの公開状態が各イラストに分かりやすく表示されること
   ⇨ #32 で実装
- [ ] 一般ユーザーと同じ表示が良いかログインユーザー向けの表示が良いか検討すること
   ⇨ゲストログイン排除につき不要に

ログインユーザーとページのユーザーが一致しないとき
- [ ] そのユーザーが投稿したイラストで、ログインユーザーがゲストログインのときは全体公開のみ取得できること
   ⇨ゲストログイン排除につき不要
- [ ] ログインユーザーがユーザーをフォローしていたとき、「全体公開」「フォロワー」の全件を取得できること
   ⇨ #148 のあとに実装

## 挙動
Postmanにて確認
| 未ログイン | ログインユーザーと一致するユーザー |
| --- | --- |
| <img src="https://i.gyazo.com/742ec72b9522ca7fbda57bbf4caa137c.png" width="400px" /> | <img src="https://i.gyazo.com/defe22c9b5224235a86955b31c7bd7a7.png" width="400px" /> |
