### PR TITLE
【feature】ユーザーページにユーザー情報と投稿一覧表示 close #32

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -14,6 +14,7 @@ class Api::V1::UsersController < Api::V1::BasesController
       posts = user.posts.map do |post|
         {
           id: post.id,
+          title: post.title,
           data: url_for(post.postable.image),
           publish_state: post.publish_state,
         }
@@ -24,6 +25,7 @@ class Api::V1::UsersController < Api::V1::BasesController
       posts = user.posts.where(publish_state: 'all_publish').map do |post|
         {
           id: post.id,
+          title: post.title,
           data: post.illust? ? url_for(post.postable.image) : nil,
         }
       end

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import * as Mantine from "@mantine/core";
-import * as UI from "@/components/ui";
-import { IndexIllustData, IUserPageEdit } from "@/types";
+import { IndexIllustData } from "@/types";
 import { Illust } from "@/components/features/illusts";
 import { useTranslations } from "next-intl";
 import * as Users from "@/components/features/users";
 import { GetFromAPI } from "@/lib";
 import useSWR from "swr";
+import { useRecoilValue } from "recoil";
+import { userState } from "@/recoilState";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function UserPage({ params }: { params: { id: string } }) {
   const { id } = params;
+  const user = useRecoilValue(userState);
   const t_UserPage = useTranslations("UserPage");
   const { data, error } = useSWR(`/users/${id}`, fetcher);
 
@@ -20,6 +22,7 @@ export default function UserPage({ params }: { params: { id: string } }) {
   if (!data) return <div>loading...</div>;
 
   const userProfile = {
+    id: data.id,
     name: data.name,
     headerImage: data.header_image,
     avatar: data.avatar,
@@ -79,7 +82,9 @@ export default function UserPage({ params }: { params: { id: string } }) {
 
                 <div className="w-full flex flex-col justify-start items-end md:items-start md:justify-start md:relative">
                   {/* ユーザー編集 */}
-                  <Users.UserEdit userProfile={userProfile} />
+                  {userProfile.id === user.id && (
+                    <Users.UserEdit userProfile={userProfile} />
+                  )}
                   <div className="hidden md:block md:h-1/3">
                     <h2 className="text-3xl">
                       <span className="pb-2 border-b-2 border-green-300 px-1 pr-3">

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@/lib";
 import { RouterPath } from "@/settings";
-import { IndexIllustData } from "@/types";
+import { IPublicState, IndexIllustData } from "@/types";
 import { Image } from "@mantine/core";
 import { useTranslations } from "next-intl";
 import dynamic from "next/dynamic";
@@ -20,34 +20,59 @@ export default function Illust({
   isUserPage?: boolean;
 }) {
   const t_General = useTranslations("General");
+
+  const getPublishRange = () => {
+    switch (illust.publishRange) {
+      case IPublicState.All:
+        return "全体公開";
+      case IPublicState.Draft:
+        return "非公開";
+      case IPublicState.URL:
+        return "URLを知っている人";
+      case IPublicState.Private:
+        return "非公開";
+      case IPublicState.Follower:
+        return "フォロワー";
+      default:
+        return "公開範囲不明";
+    }
+  };
+
   return (
     <section className="relative overflow-hidden">
       <Link href={RouterPath.illust(illust.id)} className="relative z-0">
         <Image
           src={illust.image}
           loading="lazy"
-          alt="タイトル" // TODO : 画像タイトル
-          className="aspect-square object-cover z-10"
+          alt={illust.title}
+          className="aspect-square object-cover z-10 bg-white"
         />
-        {illust.count > 1 && (
+        {illust.count && illust.count > 1 && (
           <MdCollections className="absolute top-2 right-2 text-white" />
         )}
       </Link>
       {isUserPage ? (
-        <div className="absolute bottom-0 right-0 text-sm text-end">
-          <Link
-            href={RouterPath.illustEdit(illust.id)}
-            className="px-2 py-1 bg-slate-600 text-white rounded-l"
-          >
-            {t_General("edit")}
-          </Link>
-        </div>
+        <>
+          <div className="absolute bottom-0 right-0 text-sm text-end">
+            <Link
+              href={RouterPath.illustEdit(illust.id)}
+              className="px-2 py-1 bg-slate-600 text-white rounded-l"
+            >
+              {t_General("edit")}
+            </Link>
+          </div>
+          <div className="absolute top-0 right-0 text-sm text-end">
+            <p className="px-2 py-1 bg-sky-300 bg-opacity-50 text-white rounded-l">
+              {getPublishRange()}
+            </p>
+          </div>
+        </>
       ) : (
         <div className="mt-2 flex ml-4 justify-start items-center gap-3">
-          <Link href={`/users/${illust.user.id}`}>
+          <Link href={`/users/${illust.user?.id}`}>
             <Image
-              src={illust.user.avatar}
-              alt={illust.user.name}
+              src={illust.user?.avatar}
+              alt={illust.user?.name}
               className="rounded-full aspect-square object-cover w-9"
             />
           </Link>

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -40,7 +40,10 @@ export default function Illust({
 
   return (
     <section className="relative overflow-hidden">
-      <Link href={RouterPath.illust(illust.id)} className="relative z-0">
+      <Link
+        href={RouterPath.illust(illust.id)}
+        className="relative z-0 hover:opacity-70 transition-all"
+      >
         <Image
           src={illust.image}
           loading="lazy"

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -33,8 +33,6 @@ export default function Illust({
         return "非公開";
       case IPublicState.Follower:
         return "フォロワー";
-      default:
-        return "公開範囲不明";
     }
   };
 
@@ -64,11 +62,13 @@ export default function Illust({
               {t_General("edit")}
             </Link>
           </div>
-          <div className="absolute top-0 right-0 text-sm text-end">
-            <p className="px-2 py-1 bg-sky-300 bg-opacity-50 text-white rounded-l">
-              {getPublishRange()}
-            </p>
-          </div>
+          {illust.publishRange && (
+            <div className="absolute top-0 right-0 text-sm text-end">
+              <p className="px-2 py-1 bg-sky-300 bg-opacity-50 text-white rounded-l">
+                {getPublishRange()}
+              </p>
+            </div>
+          )}
         </>
       ) : (
         <div className="mt-2 flex ml-4 justify-start items-center gap-3">

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -175,7 +175,7 @@ export default function UserEdit({
                 }}
               >
                 <MantineDropzone.Dropzone.Idle>
-                  {headerImageBlob.length > 0 && (
+                  {headerImageBlob && (
                     <MantineCore.Image
                       src={headerImageBlob}
                       h={mobile ? "8rem" : "15rem"}
@@ -209,7 +209,7 @@ export default function UserEdit({
                   }}
                 >
                   <MantineDropzone.Dropzone.Idle>
-                    {avatarBlob.length > 0 && (
+                    {avatarBlob && (
                       <MantineCore.Image
                         src={avatarBlob}
                         fit="cover"

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -24,13 +24,20 @@ export default function UserTabs() {
 
   return (
     <Mantine.Tabs value={value} onChange={handleChange}>
-      <Mantine.Tabs.List aria-label="一覧切り替え">
-        <Mantine.Tabs.Tab value={Tab.post}>
+      <Mantine.Tabs.List
+        aria-label="一覧切り替え"
+        className="before:border-none"
+      >
+        <Mantine.Tabs.Tab
+          value={Tab.post}
+          className="border-green-400 transition-all hover:bg-transparent cursor-default"
+        >
           {t_UserPage("post")}
         </Mantine.Tabs.Tab>
-        <Mantine.Tabs.Tab value={Tab.bookmark}>
+        {/* TODO : ブックマーク機能を追加したら追加 */}
+        {/* <Mantine.Tabs.Tab value={Tab.bookmark}>
           {t_UserPage("bookmark")}
-        </Mantine.Tabs.Tab>
+        </Mantine.Tabs.Tab> */}
       </Mantine.Tabs.List>
     </Mantine.Tabs>
   );

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -13,12 +13,13 @@ export interface IndexIllustData {
   id: number;
   title: string;
   image: string;
-  user: {
+  user?: {
     id: number;
     name: string;
     avatar: string;
   };
-  count: number;
+  count?: number;
+  publishRange?: string;
 }
 
 export interface IEditIllustData {


### PR DESCRIPTION
# 概要
ユーザーページにユーザー情報とユーザーが投稿したイラスト一覧を表示させました。

## 実装項目
- [x] ユーザー情報の表示がされること
- [x] イラスト一覧が表示されること
- [ ] ブックマーク一覧が表示されること
   ⇨ #146 で実装
- [x] レイアウト崩れが起きないこと
- [ ] ページネーションが件数に応じて表示されること
   ⇨ サービス開始時はページネーションさせるほどコンテンツが揃っていないので後回し
- [x] ページに合わせて表示されること

## 追加実装項目
- [x] ログインユーザーと一致するときは公開範囲も表示

## 挙動
| 未ログインPC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/1a38068004f31a9b18efc77d99868d13.png" width="550px" /> | <img src="https://i.gyazo.com/d656161d2f7b7827b346454d81a305a1.png" width="225px" /> |

| ログインユーザーと一致PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/b915d966b3388161c6d7718d3c0bfbe9.png" width="545px" /> | <img src="https://i.gyazo.com/c7ddeca0f31c3e9d35b7d801c3058dcc.png" width="230px" /> |
