### PR TITLE
【feature】Google, Discord認証を実装 close #124

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -36,7 +36,7 @@ gem 'rails_same_site_cookie'
 # 認証
 gem "devise"
 # トークンの方はRails7に対応していないので、githubから取得
-gem 'devise_token_auth', '>= 1.2.0', git: "https://github.com/lynndylanhurley/devise_token_auth"
+gem 'devise_token_auth', '>= 1.2.0', git: 'https://github.com/lynndylanhurley/devise_token_auth'
 # 多言語用
 gem 'devise-i18n'
 # OAuth2.0用

--- a/back/app/controllers/api/v1/accounts_controller.rb
+++ b/back/app/controllers/api/v1/accounts_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::AccountsController < Api::V1::BasesController
       end
     end.reduce({}, :merge) # マージして1つのハッシュにする
 
-    render json: {account: account,notices: notices}, status: :ok
+    render json: {account: account, notices: notices}, status: :ok
   end
 
   def update

--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,30 +1,30 @@
 class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCallbacksController
   # オーバーライド
   def redirect_callbacks
-    auth = Authentiction.find_for_oauth(request.env['omniauth.auth'])
-
     # トークンを生成
     client_id = SecureRandom.urlsafe_base64(nil, false)
     token     = SecureRandom.urlsafe_base64(nil, false)
     token_hash = BCrypt::Password.create(token)
     expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
+    auth = Authentication.find_for_oauth(request.env['omniauth.auth'])
     # ユーザーがいたらログイン
     if auth.present?
       user = auth.user
       sign_in(user)
       save_to_redirect(user, token_hash, client_id, token, expiry)
     else
-      # ユーザーがいなかったら同じメールアドレスのユーザーが居るか確認
-      user = User.from_omniauth(request.env['omniauth.auth'])
+      User.transaction do
+        # 同じメールアドレスのユーザーがいるか
+        # いなかったら作成する
+        user = User.from_omniauth(request.env['omniauth.auth'])
 
-      if user.persisted?
-        sign_in(user)
-        # ユーザーがいたら、認証情報を追加
-        user.authentications.create(provider: request.env['omniauth.auth'].provider, uid: request.env['omniauth.auth'].uid)
-        save_to_redirect(user, token_hash, client_id, token, expiry)
-      else
-        redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+        if user.persisted?
+          sign_in(user)
+          save_to_redirect(user, token_hash, client_id, token, expiry)
+        else
+          redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+        end
       end
     end
   end
@@ -39,9 +39,14 @@ class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCal
     }
 
     if user.save
-      redirect_to "#{ENV['FRONT_URL']}/ja/tasks?uid=#{user.uid}&token=#{token}&client=#{client_id}&expiry=#{expiry}", allow_other_host: true
+      redirect_to "#{ENV['FRONT_URL']}/ja?uid=#{user.uid}&token=#{token}&client=#{client_id}&expiry=#{expiry}", allow_other_host: true
     else
-      redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+      redirect_to "#{ENV['FRONT_URL']}/ja?status=error", allow_other_host: true
     end
+  end
+
+  # リソースクラスが取得できないエラーが出るので明示する
+  def resource_class
+    User
   end
 end

--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -14,8 +14,4 @@ class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
       user: @resource.as_header_json,
     }
   end
-
-  def resource_name
-    :user
-  end
 end

--- a/back/config/settings/development.yml
+++ b/back/config/settings/development.yml
@@ -1,3 +1,4 @@
 default_url_options:
   host: "localhost"
   port: 3000
+  protocol: "http"

--- a/back/config/settings/production.yml
+++ b/back/config/settings/production.yml
@@ -1,0 +1,3 @@
+default_url_options:
+  host: <%= ENV['HOST'] %>
+  protocol: https

--- a/front/src/app/[locale]/account/page.tsx
+++ b/front/src/app/[locale]/account/page.tsx
@@ -8,7 +8,7 @@ import { GetFromAPI } from "@/lib";
 interface AccountProps {
   name: string;
   email?: string;
-  google?: string;
+  google_oauth2?: string;
   discord?: string;
 }
 
@@ -16,11 +16,11 @@ const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function AccountPage() {
   const { data, error } = useSWR("/account", fetcher);
-  const account = data?.account as AccountProps;
   const t_AccountSettings = useTranslations("AccountSettings");
   // TODO : ローディング・エラー画面
   if (error) return <div>error</div>;
   if (data === undefined) return <div>Now Loading</div>;
+  const account = data?.account as AccountProps;
 
   return (
     <article className="my-8 m-auto w-full px-4">
@@ -50,12 +50,12 @@ export default function AccountPage() {
             <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2 flex justify-start items-start flex-wrap gap-2">
               <span
                 className={`border rounded text-xs px-2 py-1  ${
-                  account.google
+                  account.google_oauth2
                     ? "border-red-500 text-red-500"
                     : "border-gray-500 text-gray-500"
                 }`}
               >
-                Google{account.google ? "連携中" : "未連携"}
+                Google{account.google_oauth2 ? "連携中" : "未連携"}
               </span>
               <span
                 className={`border rounded text-xs px-2 py-1  ${
@@ -67,20 +67,22 @@ export default function AccountPage() {
                 Discord{data.account.discord ? "連携中" : "未連携"}
               </span>
             </dd>
-            <dt className="md:border-b md:border-slate-300 md:pb-2">
+            {/* TODO : パスワード再設定はあとにする */}
+            {/* <dt className="md:border-b md:border-slate-300 md:pb-2">
               {t_AccountSettings("password")}
             </dt>
             <dd className="ml-4 md:ml-0 border-b border-slate-300 pb-2">
               <button className="text-sm text-blue-500 underline hover:opacity-50 transition-all">
                 {t_AccountSettings("changePassword")}
               </button>
-            </dd>
+            </dd> */}
           </dl>
 
-          <h3 className="text-xl font-semibold text-center mt-10 mb-2">
+          {/* TODO : 通知設定はあとにする */}
+          {/* <h3 className="text-xl font-semibold text-center mt-10 mb-2">
             {t_AccountSettings("notificationSettings")}
           </h3>
-          <NoticeTabs INoticeStates={data.notices} />
+          <NoticeTabs noticeState={data.notices} /> */}
         </section>
       </div>
     </article>

--- a/front/src/app/[locale]/login/page.tsx
+++ b/front/src/app/[locale]/login/page.tsx
@@ -82,12 +82,13 @@ export default function LoginPage() {
             >
               {t_Auth("toSignUp")}
             </Link>
-            <Link
+            {/* TODO : パスワードリセットは後回し */}
+            {/* <Link
               href="/forgot-password"
               className="underline hover:opacity-50 transition-all"
             >
               {t_Auth("toPasswordReset")}
-            </Link>
+            </Link> */}
           </div>
           <div className="w-full relative h-10">
             <div className="border-t border-green-400 w-full text-center overflow-visible absolute top-1/2 left-0" />

--- a/front/src/components/features/account/notice.tsx
+++ b/front/src/components/features/account/notice.tsx
@@ -15,19 +15,19 @@ interface TabPanelProps {
   children?: React.ReactNode;
   index: string;
   value: string;
-  INoticeState: INoticeState;
+  noticeState: INoticeState;
   setNewNoticeState: React.Dispatch<React.SetStateAction<INoticeStates>>;
 }
 
 export default function NoticeTabs({
-  INoticeStates,
+  noticeState,
 }: {
-  INoticeStates: INoticeStates;
+  noticeState: INoticeStates;
 }) {
   const [value, setValue] = useState<string>(NoticeType.app);
   const t_AccountSettings = useTranslations("AccountSettings");
   const [newNoticeState, setNewNoticeState] =
-    useState<INoticeStates>(INoticeStates);
+    useState<INoticeStates>(noticeState);
   const t_General = useTranslations("General");
 
   const handleChange = (newValue: string | null) => {
@@ -66,7 +66,7 @@ export default function NoticeTabs({
           <NoticePanel
             value={value}
             index={NoticeType.app}
-            INoticeState={newNoticeState.app}
+            noticeState={newNoticeState.app}
             setNewNoticeState={setNewNoticeState}
           />
         </Mantine.Tabs.Panel>
@@ -74,7 +74,7 @@ export default function NoticeTabs({
           <NoticePanel
             value={value}
             index={NoticeType.email}
-            INoticeState={newNoticeState.email}
+            noticeState={newNoticeState.email}
             setNewNoticeState={setNewNoticeState}
           />
         </Mantine.Tabs.Panel>
@@ -89,12 +89,12 @@ export default function NoticeTabs({
 }
 
 function NoticePanel(props: TabPanelProps) {
-  const { value, index, INoticeState, setNewNoticeState, ...other } = props;
+  const { value, index, noticeState, setNewNoticeState, ...other } = props;
   const t_AccountSettings = useTranslations("AccountSettings");
 
   const handleChange = (key: string, value: boolean) => {
     const newNoticeState = {
-      ...INoticeState,
+      ...noticeState,
       [key]: value,
     };
     setNewNoticeState((prevState) => ({
@@ -116,23 +116,23 @@ function NoticePanel(props: TabPanelProps) {
         <>
           <Mantine.Switch
             label={t_AccountSettings("favorite")}
-            checked={INoticeState.favorite}
-            onChange={() => handleChange("favorite", !INoticeState.favorite)}
+            checked={noticeState.favorite}
+            onChange={() => handleChange("favorite", !noticeState.favorite)}
           />
           <Mantine.Switch
             label={t_AccountSettings("bookmark")}
-            checked={INoticeState.bookmark}
-            onChange={() => handleChange("bookmark", !INoticeState.bookmark)}
+            checked={noticeState.bookmark}
+            onChange={() => handleChange("bookmark", !noticeState.bookmark)}
           />
           <Mantine.Switch
             label={t_AccountSettings("comment")}
-            checked={INoticeState.comment}
-            onChange={() => handleChange("comment", !INoticeState.comment)}
+            checked={noticeState.comment}
+            onChange={() => handleChange("comment", !noticeState.comment)}
           />
           <Mantine.Switch
             label={t_AccountSettings("follower")}
-            checked={INoticeState.follower}
-            onChange={() => handleChange("follower", !INoticeState.follower)}
+            checked={noticeState.follower}
+            onChange={() => handleChange("follower", !noticeState.follower)}
           />
         </>
       )}

--- a/front/src/components/features/auth/loginWith.tsx
+++ b/front/src/components/features/auth/loginWith.tsx
@@ -1,27 +1,21 @@
 "use client";
 
 import { DiscordIcon, GoogleIcon } from "@/components/ui/iconsButton";
+import { useAuth } from "@/hook";
 import { useTranslations } from "next-intl";
 
 export default function LoginWith({ state }: { state: string }) {
   const t_Auth = useTranslations("Auth");
-
-  const loginWithGoogle = () => {
-    // TODO : Google新規登録処理を書く
-  };
-
-  const loginWithDiscord = () => {
-    // TODO : Discord新規登録処理を書く
-  };
+  const { loginWithGoogle, loginWithDiscord } = useAuth();
 
   return (
     <div className="w-full grid grid-cols-1 gap-2 justify-start items-center md:grid-cols-2">
       <GoogleIcon
-        onClick={loginWithGoogle}
+        onClick={() => loginWithGoogle()}
         message={t_Auth(`${state}WithGoogle`)}
       />
       <DiscordIcon
-        onClick={loginWithDiscord}
+        onClick={() => loginWithDiscord()}
         message={t_Auth(`${state}WithDiscord`)}
       />
     </div>

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -17,13 +17,30 @@ import SpHeaders from "./spHeaders";
 
 export default function Headers() {
   const [user, setUser] = useRecoilState(RecoilState.userState);
-  const { autoLogin, logout } = useAuth();
+  const { autoLogin, logout, setAccessTokens } = useAuth();
   const t_Header = useTranslations("Header");
   const [search, setSearch] = useState("");
   const router = useRouter();
+
   useEffect(() => {
     if (user.name !== "") return;
     const fetchData = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const status = params.get("status");
+      if (status === "error") {
+        // TODO : 表示方法を考える
+        alert("ログインに失敗しました。");
+        return;
+      }
+
+      const accessToken = params.get("token");
+      const uid = params.get("uid");
+      const client = params.get("client");
+      const expiry = params.get("expiry");
+      if (!accessToken || !uid || !client || !expiry) return;
+
+      setAccessTokens(accessToken, client, uid, expiry);
+
       const result = await autoLogin();
       if (result.success && result.user) {
         setUser(result.user);

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -167,8 +167,8 @@ export function AccountMenu({
       <Mantine.Menu.Target>
         <Mantine.Avatar
           alt="icon"
-          variant="light"
-          src={user.avatar ? user.avatar : "https://placehold.jp/300x300.png"}
+          variant="default"
+          src={user.avatar}
           className="cursor-pointer"
           radius="xl"
           size="lg"
@@ -179,10 +179,8 @@ export function AccountMenu({
           <div className="flex justify-start items-center">
             <Mantine.Avatar
               alt="icon"
-              src={
-                user.avatar ? user.avatar : "https://placehold.jp/300x300.png"
-              }
-              variant="light"
+              src={user.avatar}
+              variant="default"
               radius="xl"
               size="lg"
             />

--- a/front/src/hook/useAuth.ts
+++ b/front/src/hook/useAuth.ts
@@ -1,4 +1,5 @@
 import { Delete2API, GetFromAPI, Post2API } from "@/lib";
+import { Settings } from "@/settings";
 import { IUser } from "@/types";
 
 export const useAuth = () => {
@@ -72,6 +73,14 @@ export const useAuth = () => {
     }
   };
 
+  const loginWithGoogle = () => {
+    window.location.href = `${Settings.API_URL}/auth/google_oauth2`;
+  };
+
+  const loginWithDiscord = () => {
+    window.location.href = `${Settings.API_URL}/auth/discord`;
+  };
+
   const autoLogin = async () => {
     try {
       const response = await GetFromAPI("/auth/validate_token");
@@ -125,5 +134,13 @@ export const useAuth = () => {
     localStorage.removeItem("expiry");
   };
 
-  return { login, signUp, autoLogin, logout };
+  return {
+    login,
+    signUp,
+    loginWithGoogle,
+    loginWithDiscord,
+    autoLogin,
+    logout,
+    setAccessTokens,
+  };
 };


### PR DESCRIPTION
# 概要
Google, Discord認証を実装しました。
新規登録・ログイン実装済みです。

## 実装項目
Google認証
- [x] 新規登録ができる
- [x] 新規登録したとき、Googleアカウント名をユーザー名として表示する
- [x] 新規登録で登録済みのメールアドレスがあれば同一ユーザーと判断する
- [x] ログインができる
- [x] ログインで登録済みのメールアドレスがあれば同一ユーザーと判断する

Discord
- [x] 新規登録ができる
- [x] 新規登録したとき、Googleアカウント名をユーザー名として表示する
- [x] 新規登録で登録済みのメールアドレスがあれば同一ユーザーと判断する
- [x] ログインができる
- [x] ログインで登録済みのメールアドレスがあれば同一ユーザーと判断する

## 補足
同一メールアドレスであれば同じユーザーと判定しています。
現在メールアドレス・パスワード認証した際に本当に所持者かどうかの判定ができてないので、登録したらメールアドレスで認証するようなシステムが必要になりそうです。

## 挙動
Google認証はメールアドレスが表示されてしまうため割愛します。
| Discord認証 | アカウント設定画面 |
| --- | --- |
| <img src="https://i.gyazo.com/7b534596ab3b5aa8cc0e513015177de2.gif" width="320px" /> | <img src="https://i.gyazo.com/f830e30094d02fa8916be8070da0e865.png" width="500px" /> |