### PR TITLE
【feature】バックで検索時における一覧取得 close #50

### DIFF
--- a/back/app/controllers/api/v1/illusts_controller.rb
+++ b/back/app/controllers/api/v1/illusts_controller.rb
@@ -2,21 +2,26 @@ class Api::V1::IllustsController < Api::V1::BasesController
   skip_before_action :authenticate_api_v1_user!, only: %i[index]
 
   def index
+    post_search = PostSearch.new(search_params)
+    search_results = []
     if search_params[:search_word].present?
-      post_search = PostSearch.new(search_params)
       search_results = post_search.search_word
-      if search_results.present?
-        posts_json = search_results.map do |post|
-          content = nil
-          if post.illust?
-            content = url_for(post.postable.image)
-          end
-          post.as_custom_index_json(content)
-        end
-      else
-      end
-      render json: {illusts: posts_json, count: search_results.count}, status: :ok
+    else
+      search_results = post_search.search_detail
     end
+
+    posts_json = []
+    if search_results.present?
+      posts_json = search_results.map do |post|
+        content = nil
+        if post.illust?
+          content = url_for(post.postable.image)
+        end
+        post.as_custom_index_json(content)
+      end
+    end
+
+    render json: { illusts: posts_json, count: search_results.count }, status: :ok
   end
 
   private

--- a/back/app/controllers/api/v1/illusts_controller.rb
+++ b/back/app/controllers/api/v1/illusts_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::IllustsController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[index]
+
+  def index
+    if search_params[:search_word].present?
+      post_search = PostSearch.new(search_params)
+      search_results = post_search.search_word
+      if search_results.present?
+        posts_json = search_results.map do |post|
+          content = nil
+          if post.illust?
+            content = url_for(post.postable.image)
+          end
+          post.as_custom_index_json(content)
+        end
+      else
+      end
+      render json: {illusts: posts_json, count: search_results.count}, status: :ok
+    end
+  end
+
+  private
+
+  def search_params
+    params.permit(:search_word, :post_title, :game_system, :synalio_name, :tags, :user_name, :search_type)
+  end
+end

--- a/back/app/controllers/api/v1/illusts_controller.rb
+++ b/back/app/controllers/api/v1/illusts_controller.rb
@@ -10,6 +10,8 @@ class Api::V1::IllustsController < Api::V1::BasesController
       search_results = post_search.search_detail
     end
 
+    search_results ||= []
+
     posts_json = []
     if search_results.present?
       posts_json = search_results.map do |post|

--- a/back/app/lib/post_search.rb
+++ b/back/app/lib/post_search.rb
@@ -10,16 +10,11 @@ class PostSearch
     game_system = GameSystem.find_by_name(search_word)
     if game_system.present?
       game_systems = PostGameSystem.where(game_system_id: game_system.id)
-      posts = Post.includes(:user)
-              .where(id: game_systems.map(&:post_id))
-              .where(publish_state: 'all_publish').order(published_at: :desc)
-      posts
+      Post.includes(:user)
+        .where(id: game_systems.map(&:post_id))
+        .where(publish_state: 'all_publish').order(published_at: :desc)
     else
-      posts = Post.joins(:user, :tags, :synalios)
-            .where(publish_state: 'all_publish')
-            .where('posts.title LIKE ? OR tags.name LIKE ? OR synalios.name LIKE ? OR users.name LIKE ?', "%#{search_word}%", "%#{search_word}%", "%#{search_word}%", "%#{search_word}%")
-            .order(published_at: :desc)
-      posts
+      or_search(search_word, search_word, search_word, search_word)
     end
   end
 
@@ -32,28 +27,44 @@ class PostSearch
     user_name = @params[:user_name]
     search_type = @params[:search_type]
 
-    posts = []
-    # ゲームシステムで検索
-    if game_system.present?
-      game_systems = PostGameSystem.where(game_system_id: game_system.id)
-      posts = Post.where(id: game_systems.map(&:post_id))
-              .where(publish_state: 'all_publish').order(published_at: :desc)
-    end
+    posts = Post.all
 
-    # AND検索
     if search_type == 'AND'
-      return posts if posts.blank?
-      # タイトル、タグ、シナリオ名、ユーザー名で検索
-      posts = posts.joins(:user, :tags, :synalios)
-              .where(publish_state: 'all_publish')
-              .where('posts.title LIKE ? AND tags.name LIKE ? AND synalios.name LIKE ? AND users.name LIKE ?', "%#{post_title}%", "%#{tag_list}%", "%#{synalio_name}%", "%#{user_name}%")
-      posts
+      # ゲームシステムで検索
+      if game_system.present?
+        game_systems = PostGameSystem.where(game_system_id: game_system.id)
+        posts = posts.where(id: game_systems.map(&:post_id))
+      end
+
+      # 全体公開のみ
+      posts = posts.where(publish_state: 'all_publish')
+      # タイトル検索
+      posts = posts.where("posts.title LIKE ?", "%#{post_title}%") if post_title.present?
+      # タグ検索
+      posts = posts.joins(:tags).where("tags.name IN (?)", tag_list) if tag_list.present?
+      # シナリオ検索
+      posts = posts.joins(:synalios).where("synalios.name LIKE ?", "%#{synalio_name}%") if synalio_name.present?
+      # ユーザー検索
+      posts = posts.joins(:user).where("users.name LIKE ?", "%#{user_name}%") if user_name.present?
+
+      posts.distinct
     else
       # OR検索
-      posts = Post.joins(:user, :tags, :synalios)
-              .where(publish_state: 'all_publish')
-              .where('posts.title LIKE ? OR tags.name LIKE ? OR synalios.name LIKE ? OR users.name LIKE ?', "%#{post_title}%", "%#{tag_list}%", "%#{synalio_name}%", "%#{user_name}%").merge(posts)
-      posts
+      posts = or_search(post_title, tag_list, synalio_name, user_name)
+      if game_system.present?
+        game_systems = PostGameSystem.where(game_system_id: game_system.id)
+        posts = posts.or(Post.where(id: game_systems.map(&:post_id)).distinct)
+      end
     end
+    posts.order(published_at: :desc)
+  end
+
+  def or_search(post_title, tag_list, synalio_name, user_name)
+    posts = Post.where(publish_state: 'all_publish')
+    posts = posts.or(Post.where("title LIKE ?", "%#{post_title}%")) if post_title.present?
+    posts = posts.joins(:tags).or(Post.where(tags: { name: tag_list })) if tag_list.present?
+    posts = posts.joins(:synalios).or(Post.where(synalios: { name: synalio_name })) if synalio_name.present?
+    posts = posts.joins(:user).or(Post.where(users: { name: user_name })) if user_name.present?
+    posts.distinct
   end
 end

--- a/back/app/lib/post_search.rb
+++ b/back/app/lib/post_search.rb
@@ -22,4 +22,38 @@ class PostSearch
       posts
     end
   end
+
+  def search_detail
+    post_title = @params[:post_title]
+    game_system = @params[:game_system].present? ? GameSystem.find_by_name(@params[:game_system]) : nil
+    synalio_name = @params[:synalio_name]
+    tags = @params[:tags]
+    tag_list = tags.split(',') if tags.present?
+    user_name = @params[:user_name]
+    search_type = @params[:search_type]
+
+    posts = []
+    # ゲームシステムで検索
+    if game_system.present?
+      game_systems = PostGameSystem.where(game_system_id: game_system.id)
+      posts = Post.where(id: game_systems.map(&:post_id))
+              .where(publish_state: 'all_publish').order(published_at: :desc)
+    end
+
+    # AND検索
+    if search_type == 'AND'
+      return posts if posts.blank?
+      # タイトル、タグ、シナリオ名、ユーザー名で検索
+      posts = posts.joins(:user, :tags, :synalios)
+              .where(publish_state: 'all_publish')
+              .where('posts.title LIKE ? AND tags.name LIKE ? AND synalios.name LIKE ? AND users.name LIKE ?', "%#{post_title}%", "%#{tag_list}%", "%#{synalio_name}%", "%#{user_name}%")
+      posts
+    else
+      # OR検索
+      posts = Post.joins(:user, :tags, :synalios)
+              .where(publish_state: 'all_publish')
+              .where('posts.title LIKE ? OR tags.name LIKE ? OR synalios.name LIKE ? OR users.name LIKE ?', "%#{post_title}%", "%#{tag_list}%", "%#{synalio_name}%", "%#{user_name}%").merge(posts)
+      posts
+    end
+  end
 end

--- a/back/app/lib/post_search.rb
+++ b/back/app/lib/post_search.rb
@@ -1,0 +1,27 @@
+class PostSearch
+  def initialize(params)
+    @params = params
+  end
+
+  def search_word
+    search_word = @params[:search_word]
+    return if search_word.blank?
+    # 先にゲームシステムで検索をかける
+    game_system = GameSystem.find_by_name(search_word)
+    if game_system.present?
+      game_systems = PostGameSystem.where(game_system_id: game_system.id)
+      posts = Post.includes(:user).where(id: game_systems.map(&:post_id)).where(publish_state: 'all_publish').order(published_at: :desc)
+      posts
+    else
+      posts = Post.includes(:user, :tags, :synalios).where(publish_state: 'all_publish')
+      posts = posts.where('title LIKE ?', "%#{search_word}%").or(posts.tags.where('name LIKE ?', "%#{search_word}%")).or(posts.synalios.where('name LIKE ?', "%#{search_word}%").or(posts.user.where('name LIKE ?', "%#{search_word}%"))).order(published_at: :desc)
+      posts.map do |post|
+        content = nil
+        if post.illust?
+          content = url_for(post.postable.image)
+        end
+        posts.as_custom_index_json(content)
+      end
+    end
+  end
+end

--- a/back/app/lib/post_search.rb
+++ b/back/app/lib/post_search.rb
@@ -10,18 +10,16 @@ class PostSearch
     game_system = GameSystem.find_by_name(search_word)
     if game_system.present?
       game_systems = PostGameSystem.where(game_system_id: game_system.id)
-      posts = Post.includes(:user).where(id: game_systems.map(&:post_id)).where(publish_state: 'all_publish').order(published_at: :desc)
+      posts = Post.includes(:user)
+              .where(id: game_systems.map(&:post_id))
+              .where(publish_state: 'all_publish').order(published_at: :desc)
       posts
     else
-      posts = Post.includes(:user, :tags, :synalios).where(publish_state: 'all_publish')
-      posts = posts.where('title LIKE ?', "%#{search_word}%").or(posts.tags.where('name LIKE ?', "%#{search_word}%")).or(posts.synalios.where('name LIKE ?', "%#{search_word}%").or(posts.user.where('name LIKE ?', "%#{search_word}%"))).order(published_at: :desc)
-      posts.map do |post|
-        content = nil
-        if post.illust?
-          content = url_for(post.postable.image)
-        end
-        posts.as_custom_index_json(content)
-      end
+      posts = Post.joins(:user, :tags, :synalios)
+            .where(publish_state: 'all_publish')
+            .where('posts.title LIKE ? OR tags.name LIKE ? OR synalios.name LIKE ? OR users.name LIKE ?', "%#{search_word}%", "%#{search_word}%", "%#{search_word}%", "%#{search_word}%")
+            .order(published_at: :desc)
+      posts
     end
   end
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -41,6 +41,6 @@ module App
     config.action_dispatch.cookies_same_site_protection = :none
     config.action_controller.forgery_protection_origin_check = false
     config.i18n.default_locale = :ja
-    config.paths.add "app/li", eager_load: true
+    config.paths.add "app/lib", eager_load: true
   end
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -41,6 +41,6 @@ module App
     config.action_dispatch.cookies_same_site_protection = :none
     config.action_controller.forgery_protection_origin_check = false
     config.i18n.default_locale = :ja
-    config.paths.add "lib", eager_load: true
+    config.paths.add "app/li", eager_load: true
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
       resources :posts, only: %i[index show create edit update destroy]
+      resources :illusts, only: %i[index]
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
       resources :game_systems, only: %i[index]


### PR DESCRIPTION
# 概要
簡易検索・複合検索での一覧取得処理を実装しました。

## 実装項目
- [x] 検索した単語で下記の検索結果を取得できる
   - [x] 作品名
   - [x] タグ
   - [x] シナリオ名
   - [x] システム名
- [x] AND検索に対応させる
- [x] OR検索に対応させる
- [ ] あいまい検索に対応させる
   ⇨直ぐに必要はないと判断し後回しにします
- [ ] 1回の取得件数に制限をかける
   ⇨サービス開始時は数が少ないので後回しにします
- [ ] 現在ページに応じた取得制限をかける（2ページ目なら1ページ目のは表示させない）
   ⇨サービス開始時は数が少ないので後回しにします
- [x] 全体公開のみ取得できる
- [x] 当てはまった合計作品数を取得できる

## 挙動
| 簡易検索 |
| --- |
| <img src="https://i.gyazo.com/8d5fb3398d66c905fdcdb576e4ff0d92.png" width="400px" /> |

| AND検索 | OR検索 |
| --- | --- |
| <img src="https://i.gyazo.com/bcd7176f700b43ba1bb7950db7185fa9.png" width="600px" /> | <img src="https://i.gyazo.com/d9b26abe675abef46283479e0ea0b7ef.png" width="330px" /> |