### PR TITLE
【fix】MVPに向けた非表示

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -85,7 +85,7 @@
     "follow": "フォロー",
     "unFollow": "フォロー解除",
     "send": "送信",
-    "requiredComment": "コメント機能はログインで使えます",
+    "requiredComment": "準備中...",
     "fusetter": "ふせったー",
     "other": "その他"
   },

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -358,11 +358,11 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
                       value={IPublicState.URL}
                       style={{ cursor: "pointer" }}
                     />
-                    <Mantine.Radio
+                    {/* <Mantine.Radio
                       label={t_PostGeneral("followerPublish")}
                       value={IPublicState.Follower}
                       style={{ cursor: "pointer" }}
-                    />
+                    /> */}
                     <Mantine.Radio
                       label={t_PostGeneral("private")}
                       value={IPublicState.Private}

--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -135,7 +135,9 @@ export default function IllustPage({
                   <div className="text-sm flex justify-center items-center md:justify-start gap-2">
                     {illustData.game_systems && (
                       <Link
-                        href={`/illusts?search=${illustData.game_systems}`}
+                        href={RouterPath.illustSearch(
+                          `gameSystem=${illustData.game_systems}`
+                        )}
                         className="bg-blue-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                       >
                         {illustData.game_systems}
@@ -143,7 +145,9 @@ export default function IllustPage({
                     )}
                     {illustData.synalio && (
                       <Link
-                        href={`/illusts?search=${illustData.synalio}`}
+                        href={RouterPath.illustSearch(
+                          `synalioName=${illustData.synalio}`
+                        )}
                         className="bg-green-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                       >
                         {illustData.synalio}
@@ -154,7 +158,7 @@ export default function IllustPage({
                     {illustData.tags.map((tag: string, i: number) => (
                       <Link
                         key={i}
-                        href={`/illusts?search=${tag}`}
+                        href={RouterPath.illustSearch(`tags=${illustData.tag}`)}
                         className="text-blue-600 hover:underline hover:opacity-60 transition-all"
                       >
                         #{tag}
@@ -212,11 +216,9 @@ export default function IllustPage({
                     src={illustData.user.avatar}
                   />
                   <div className="flex flex-col gap-2 w-full">
-                    <span className="p-0 m-0 font-semibold">ユーザー名</span>
+                    <span className="p-0 m-0 font-semibold"></span>
                     <Mantine.Textarea
-                      aria-label="コメント"
                       minRows={3}
-                      placeholder="コメント"
                       className="w-full bg-gray-200 rounded p-2 focus:outline-none resize-none"
                       autosize
                     />
@@ -237,7 +239,7 @@ export default function IllustPage({
               </div>
             </section>
 
-            <section>
+            {/* <section>
               <ul className="bg-slate-100 rounded p-3 flex flex-col">
                 {Array.from({ length: 10 }).map((_, i) => (
                   <li
@@ -263,7 +265,7 @@ export default function IllustPage({
                   </li>
                 ))}
               </ul>
-            </section>
+            </section> */}
           </article>
         </div>
 
@@ -284,7 +286,7 @@ export default function IllustPage({
                 <Link href="/users/1" className="text-xl">
                   {illustData.user.name}
                 </Link>
-                {follow ? (
+                {/* {follow ? (
                   <Mantine.Button
                     variant="outlined"
                     size="small"
@@ -302,10 +304,10 @@ export default function IllustPage({
                   >
                     {t_ShowPost("follow")}
                   </Mantine.Button>
-                )}
+                )} */}
               </div>
             </div>
-            <div className="flex flex-wrap gap-3">
+            {/* <div className="flex flex-wrap gap-3">
               <Link href="" className="bg-slate-300 rounded px-2">
                 X
               </Link>
@@ -321,7 +323,7 @@ export default function IllustPage({
               <Link href="" className="bg-slate-300 rounded px-2">
                 {t_ShowPost("other")}
               </Link>
-            </div>
+            </div> */}
             <div>
               <p>{illustData.user.profile}</p>
             </div>

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -264,11 +264,11 @@ export default function IllustPostPage() {
                       value={IPublicState.URL}
                       style={{ cursor: "pointer" }}
                     />
-                    <Mantine.Radio
+                    {/* <Mantine.Radio
                       label={t_PostGeneral("followerPublish")}
                       value={IPublicState.Follower}
                       style={{ cursor: "pointer" }}
-                    />
+                    /> */}
                     <Mantine.Radio
                       label={t_PostGeneral("private")}
                       value={IPublicState.Private}

--- a/front/src/app/[locale]/page.tsx
+++ b/front/src/app/[locale]/page.tsx
@@ -8,8 +8,8 @@ const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function Home() {
   const { data, error } = useSWR("/posts", fetcher);
-  if (error) return <div>error</div>;
-  if (!data) return <div>loading...</div>;
+  if (error) return;
+  if (!data) return;
 
   const illusts = data.map(
     (illust: {
@@ -33,5 +33,9 @@ export default function Home() {
     })
   );
 
-  return <HomeParallax illusts={illusts} />;
+  return (
+    <>
+      <HomeParallax illusts={illusts} />
+    </>
+  );
 }

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -82,9 +82,9 @@ export default function UserPage({ params }: { params: { id: string } }) {
 
                 <div className="w-full flex flex-col justify-start items-end md:items-start md:justify-start md:relative">
                   {/* ユーザー編集 */}
-                  {userProfile.id === user.id && (
+                  {/* {userProfile.id === user.id && (
                     <Users.UserEdit userProfile={userProfile} />
-                  )}
+                  )} */}
                   <div className="hidden md:block md:h-1/3">
                     <h2 className="text-3xl">
                       <span className="pb-2 border-b-2 border-green-300 px-1 pr-3">

--- a/front/src/components/layouts/footers.tsx
+++ b/front/src/components/layouts/footers.tsx
@@ -14,7 +14,7 @@ export default function Footers() {
         <p className="md:hidden text-sm">©2024 AStoryer -あすとりや-</p>
       </div>
       <section className="text-sm md:text-normal md:mr-8 md:flex md:flex-col md:gap-3">
-        <nav>
+        {/* <nav>
           <ul className="flex flex-col gap-1 md:gap-3 md:flex-row">
             <li>
               <Link href="/about" className="hover:opacity-80 transition-all">
@@ -43,7 +43,7 @@ export default function Footers() {
               </Link>
             </li>
           </ul>
-        </nav>
+        </nav> */}
         <p className="hidden md:block">©2024 AStoryer -あすとりや-</p>
       </section>
     </footer>

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -78,16 +78,9 @@ export default function Headers() {
   return (
     <>
       <header className="p-2 flex justify-center md:justify-between items-center ml-2 md:mx-8 md:my-2">
-        <h1>
-          <Link href={RouterPath.home}>
-            <Image
-              src="/logo.png"
-              width={150}
-              height={300}
-              style={{ width: "150px", height: "auto" }}
-              alt="logo"
-              priority={true}
-            />
+        <h1 className="text-3xl font-semibold">
+          <Link href="/" className="flex flex-col justify-center items-center">
+            AStoryer <span className="text-sm">- あすとりや -</span>
           </Link>
         </h1>
         <div className="md:flex md:items-center md:justify-center md:gap-8">
@@ -178,7 +171,9 @@ export function AccountMenu({
         />
       </Mantine.Menu.Target>
       <Mantine.Menu.Dropdown>
-        <Mantine.Menu.Item onClick={() => handleLink(RouterPath.users(1))}>
+        <Mantine.Menu.Item
+          onClick={() => handleLink(RouterPath.users(user.id))}
+        >
           <div className="flex justify-start items-center">
             <Mantine.Avatar
               alt="icon"
@@ -190,7 +185,7 @@ export function AccountMenu({
             <span className="ml-4">{user.name}</span>
           </div>
         </Mantine.Menu.Item>
-        <div className="flex justify-center items-center">
+        {/* <div className="flex justify-center items-center">
           <Mantine.Menu.Item
             onClick={() => handleLink(RouterPath.users(user.id))}
           >
@@ -207,19 +202,19 @@ export function AccountMenu({
               <span>{user.follower_count}</span>
             </div>
           </Mantine.Menu.Item>
-        </div>
+        </div> */}
         <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.users(user.id))}
           leftSection={<VscAccount />}
         >
           {t_Menu("myPage")}
         </Mantine.Menu.Item>
-        <Mantine.Menu.Item
+        {/* <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.bookmark(user.id))}
           leftSection={<FaRegBookmark />}
         >
           {t_Menu("bookmark")}
-        </Mantine.Menu.Item>
+        </Mantine.Menu.Item> */}
         <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.account)}
           leftSection={<IoMdSettings />}


### PR DESCRIPTION
# 概要
MVPリリースに向け、未実装の項目を非表示にしました。

## 非表示項目
非表示にした項目は以下のとおりです
全体
- aboutへの遷移
- 利用規約への遷移
- プライバシーポリシーへの遷移
- お問い合わせへの遷移
- ログインユーザーのフォロー・フォロワー人数
- ログインユーザーのブックマークへの遷移

イラスト詳細
- コメント機能をログイン必須文言から「Coming soon...」に変更
- ハードコーディングしていたコメント部分を非表示
- 投稿者のフォロー・フォロー解除ボタン
- 投稿者の登録しているリンク集

イラスト投稿・イラスト編集
- フォローユーザーのみの範囲を非表示

