### PR TITLE
【fix】タグリンクがundefinedになる不具合修正

### DIFF
--- a/front/src/app/[locale]/illusts/[id]/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/page.tsx
@@ -158,7 +158,7 @@ export default function IllustPage({
                     {illustData.tags.map((tag: string, i: number) => (
                       <Link
                         key={i}
-                        href={RouterPath.illustSearch(`tags=${illustData.tag}`)}
+                        href={RouterPath.illustSearch(`tags=${tag}`)}
                         className="text-blue-600 hover:underline hover:opacity-60 transition-all"
                       >
                         #{tag}

--- a/front/src/components/ui/iconsButton/iconButtonList.tsx
+++ b/front/src/components/ui/iconsButton/iconButtonList.tsx
@@ -17,15 +17,15 @@ export function IconButtonList({
           <li className="mx-2 h-full text-center">
             <FavoriteButton postId={postId} />
           </li>
-          <li className="mx-2 h-full text-center">
+          {/* <li className="mx-2 h-full text-center">
             <BookmarkButton postId={postId} />
-          </li>
+          </li> */}
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState === IPublicState.All && (
+          {/* {publicState === IPublicState.All && (
             <li className="mx-2 h-full text-center">
               <ShareButton />
             </li>
-          )}
+          )} */}
         </ul>
       </div>
       <RequiredLoginModal />
@@ -48,15 +48,15 @@ export function FixedIconButtonList({
           <li className="h-full mx-2 text-center">
             <FavoriteButton postId={postId} />
           </li>
-          <li className="h-full mx-2 text-center">
+          {/* <li className="h-full mx-2 text-center">
             <BookmarkButton postId={postId} />
-          </li>
+          </li> */}
           {/* 公開範囲が全体のときのみシェア可能 */}
-          {publicState === IPublicState.All && (
+          {/* {publicState === IPublicState.All && (
             <li className="h-full mx-2 text-center">
               <ShareButton />
             </li>
-          )}
+          )} */}
         </ul>
       </article>
       <RequiredLoginModal />


### PR DESCRIPTION
# 概要
イラスト詳細ページでタグリンクを踏むとundefinedになり正常に動作しない不具合を修正しました。

## 追加実装
イラスト詳細でブックマークボタンとシェアボタンが表示状態だったので、一度非表示にしました。