### PR TITLE
【fix】ユーザー名検索出来ない不具合修正

### DIFF
--- a/back/app/lib/post_search.rb
+++ b/back/app/lib/post_search.rb
@@ -24,11 +24,11 @@ class PostSearch
     if search_type == 'AND'
       # ゲームシステムで検索
       posts = and_search(post_title, tag_list, synalio_name, user_name, game_system)
-      return posts.order(published_at: :desc).distinct if posts.exists?
+      return posts.order(published_at: :desc) if posts.exists?
     else
       # OR検索
       posts = or_search(post_title, tag_list, synalio_name, user_name, game_system)
-      return posts.order(published_at: :desc).distinct if posts.exists?
+      return posts.order(published_at: :desc) if posts.exists?
     end
   end
 


### PR DESCRIPTION
# 概要
ユーザー名検索できない不具合を修正しました。

## 原因
UserモデルにはDeviseTokenAuthによるJSON形式のトークンデータがあります。
JSON形式のデータは等価演算ができず、nameで比較していてもエラーが発生しているようでした。
PostgreSQLの`distinct`は全ての列の重複を確認してるようで、その結果トークン情報のあるJSONも比較して発生した不具合のようです。
以下発生していたエラーです。
```bash
back_1   | ActiveRecord::StatementInvalid (PG::UndefinedFunction: ERROR:  could not identify an equality operator for type json
back_1   | LINE 1: ...users"."email" AS t1_r5, "users"."role" AS t1_r6, "users"."t...
back_1   |
     ^
back_1   | ):
```

## 参考記事
[herokuでデプロイしたあとに、データの取得ができない部分がある](https://teratail.com/questions/203321)
[【PostgreSQL】重複行削除で使えるDISTINCT ON](https://qiita.com/katsunory/items/4b2faa753cce65d8cba0)
[日本PostgreSQLユーザ会 7.3.3. DISTINCT](https://www.postgresql.jp/document/16/html/queries-select-lists.html#QUERIES-DISTINCT)