### PR TITLE
【hotfix】下書き編集時に下書き保存できない不具合修正 close #204

### DIFF
--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -13,7 +13,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { FaImage } from "rocketicons/fa";
-import useSWR, { mutate, useSWRConfig } from "swr";
+import useSWR, { mutate } from "swr";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -27,7 +27,6 @@ const fetcherGameSystems = (url: string) =>
 
 export default function IllustEditPage({ params }: { params: { id: string } }) {
   const { id } = params;
-  const { cache } = useSWRConfig();
   const { data, error } = useSWR(`/posts/${id}/edit`, fetcher);
   const illustData = data
     ? ({
@@ -153,9 +152,8 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
         setErrorMessage(t_EditGeneral("updateError"));
         return;
       }
-      cache.delete(`/posts/${id}/edit`);
-      cache.delete(`/posts/${id}`);
-      router.push(RouterPath.users(user.id));
+      mutate(`/posts/${id}/edit`);
+      mutate(`/posts/${id}`);
     } catch (e) {
       setErrorMessage(t_EditGeneral("updateError"));
       return;
@@ -204,10 +202,8 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
     setIsDelete(false);
     setIsDeleteConfirmation(false);
     setDeleteConfirmationError("");
-    if (form.values.publishRange !== IPublicState.Draft && !isDelete) {
-      router.push(RouterPath.users(user.id));
-    }
     setOpenModal(false);
+    router.back();
   };
 
   return (

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -13,7 +13,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { FaImage } from "rocketicons/fa";
-import useSWR, { useSWRConfig } from "swr";
+import useSWR, { mutate, useSWRConfig } from "swr";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -69,12 +69,13 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
 
   const form = useForm({
     initialValues: {
-      postIllust: illustData?.image,
-      title: illustData?.title,
-      caption: illustData?.caption,
-      publishRange: illustData?.publish_state,
-      synalioTitle: illustData?.synalio,
-      gameSystem: illustData?.game_system,
+      postIllust: illustData?.image || [],
+      title: illustData?.title || "",
+      caption: illustData?.caption || "",
+      publishRange: illustData?.publish_state || "",
+      synalioTitle: illustData?.synalio || "",
+      gameSystem: illustData?.game_system || "",
+      tags: illustData?.tags || [],
     },
     validate: {
       postIllust: () => {
@@ -100,6 +101,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
       return;
     }
     setPostIllust(illustData.image ?? []);
+    setTags(illustData.tags ?? []);
     form.setValues({
       postIllust: illustData.image,
       title: illustData?.title,
@@ -153,6 +155,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
       }
       cache.delete(`/posts/${id}/edit`);
       cache.delete(`/posts/${id}`);
+      router.push(RouterPath.users(user.id));
     } catch (e) {
       setErrorMessage(t_EditGeneral("updateError"));
       return;
@@ -178,7 +181,8 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
         setErrorMessage(t_EditGeneral("deleteError"));
         return;
       }
-      router.push(RouterPath.users(user.id));
+      mutate(`/posts/${id}/edit`);
+      mutate(`/posts/${id}`);
     } catch (e) {
       setErrorMessage(t_EditGeneral("deleteError"));
       return;

--- a/front/src/app/[locale]/illusts/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[id]/edit/page.tsx
@@ -329,7 +329,7 @@ export default function IllustEditPage({ params }: { params: { id: string } }) {
               </section>
               <section className="flex gap-5 flex-col md:flex-row md:items-center md:gap-2 w-full ">
                 <div className="md:w-1/3">
-                  <Mantine.Select
+                  <Mantine.Autocomplete
                     name="gameSystem"
                     label={t_PostGeneral("gameSystem")}
                     data={GameSystems}


### PR DESCRIPTION
# 概要
下書きの編集時に下書き保存をするとローディング画面のまま動かない不具合を修正しました。

## 原因
useSWRはキャッシュをもとに読み込みの高速化をしていますが、編集や編集後の投稿詳細ではキャッシュではなく最新データを取得してほしいです。
これまでキャッシュ削除の処理を実装していましたが、最新を取得する処理に変更しました。
これにより不具合が解消しました。

## 追加実装
ゲームシステムがオートコンプリートではなくセレクトになっていたので合わせて修正しました。