### PR TITLE
【fix】投稿の容量上限を20MBまで上げる

### DIFF
--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -115,7 +115,8 @@
   "PostIllust": {
     "title": "イラスト投稿",
     "upload": "イラストアップロード",
-    "uploadValid": "イラストをアップロードしてください"
+    "uploadValid": "イラストをアップロードしてください",
+    "maxSize": "※ファイルサイズは10MBまでです"
   },
   "PostIllustEdit": {
     "title": "イラスト編集",

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -43,6 +43,8 @@ export default function IllustPostPage() {
   const t_PostGeneral = useTranslations("PostGeneral");
   const TITLE_MAX_LENGTH = 20;
   const CAPTION_MAX_LENGTH = 10000;
+  const MEGA_BITE = 1024 ** 2;
+  const MAX_SIZE = 10 * MEGA_BITE;
 
   const form = useForm({
     initialValues: {
@@ -160,10 +162,11 @@ export default function IllustPostPage() {
                   {t_PostIllust("upload")}
                   <span className="text-red-600">*</span>
                 </label>
+                <p className="text-sm">{t_PostIllust("maxSize")}</p>
                 <Dropzone
                   name="postIllust"
                   onDrop={(files) => handleDrop(files)}
-                  maxSize={5 * 1024 ** 2}
+                  maxSize={MAX_SIZE}
                   accept={IMAGE_MIME_TYPE}
                   style={{
                     height: mobile ? "15rem" : "30rem",


### PR DESCRIPTION
# 概要
ファイルの容量の上限を20MBに上げました。
それにともない注意書きを追記しています。

## 挙動
<img src="https://i.gyazo.com/f0bba31d73fb54c80803a99173c4da04.png" width="400px" />