### PR TITLE
【feature】ブックマーク一覧 close #31

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,12 @@
 class Api::V1::UsersController < Api::V1::BasesController
   skip_before_action :authenticate_api_v1_user!, only: %i[show bookmarks]
-  before_action :set_user, only: %i[show bookmarks]
+  before_action :set_user, only: %i[show postsIllust bookmarks]
 
   def show
+    render json: @user.as_custom_json, status: :ok
+  end
+
+  def postsIllust
     posts = []
     # ログインユーザーと表示ユーザーが同じ場合は全ての投稿を取得
     if(current_api_v1_user && current_api_v1_user.uuid == @user.uuid)
@@ -25,8 +29,7 @@ class Api::V1::UsersController < Api::V1::BasesController
         }
       end
     end
-
-    render json: @user.as_custom_json(posts), status: :ok
+    render json: posts, status: :ok
   end
 
   def bookmarks

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -37,6 +37,7 @@ class Post < ApplicationRecord
   scope :search_by_synalio, ->(synalio_name) { joins(:synalios).where("synalios.name LIKE ?", "%#{synalio_name}%") }
   scope :search_by_user, ->(user_name) { joins(:user).where("users.name LIKE ?", "%#{user_name}%") }
   scope :only_publish, -> { where(publish_state: 'all_publish') }
+  scope :publish_at_desc, -> { order(published_at: :desc) }
 
   scope :useful_joins, -> { joins(:user, :tags, :synalios) }
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -110,7 +110,6 @@ class User < ActiveRecord::Base
       profile: profile&.text,
       following_count: following.count || 0,
       follower_count: followers.count || 0,
-      posts: posts,
     }
   end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -37,6 +37,7 @@ class User < ActiveRecord::Base
 
   has_many :favorites, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
   has_many :bookmarks, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
 
   enum role: { general: 0, admin: 1 } # general: 一般ユーザー, admin: 管理者
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]
       resources :game_systems, only: %i[index]
-      resources :users, only: %i[show]
+      resources :users, only: %i[show] do
+        get 'bookmarks', on: :member
+      end
       resources :favorites, only: %i[show create destroy]
       resources :bookmarks, only: %i[show create destroy]
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
       resources :synalios, only: %i[index]
       resources :game_systems, only: %i[index]
       resources :users, only: %i[show] do
-        get 'bookmarks', on: :member
+        member do
+          get 'bookmarks'
+          get 'postsIllust'
+        end
       end
       resources :favorites, only: %i[show create destroy]
       resources :bookmarks, only: %i[show create destroy]

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -1,14 +1,10 @@
 "use client";
 
 import * as Mantine from "@mantine/core";
-import { IndexIllustData } from "@/types";
-import { Illust } from "@/components/features/illusts";
 import { useTranslations } from "next-intl";
 import * as Users from "@/components/features/users";
 import { GetFromAPI } from "@/lib";
 import useSWR from "swr";
-import { useRecoilValue } from "recoil";
-import { userState } from "@/recoilState";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -34,22 +30,6 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
     },
     profile: data.profile,
   };
-
-  const illusts = data.posts.map(
-    (illust: {
-      uuid: string;
-      title: string;
-      data: string;
-      publish_state?: string;
-    }) => {
-      return {
-        uuid: illust.uuid,
-        title: illust.title,
-        image: illust.data,
-        publishRange: illust.publish_state ?? null,
-      };
-    }
-  );
 
   return (
     <>
@@ -167,22 +147,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
 
       {/* イラスト一覧 */}
       <article className="mb-16">
-        <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
-          <Users.UserTabs />
-        </section>
-        <section className="container my-2 m-auto">
-          <div className="grid grid-cols-2 md:mx-auto md:grid-cols-4 mx-2 gap-1">
-            {illusts.map((illust: IndexIllustData) => (
-              <div key={illust.uuid}>
-                <Illust illust={illust} />
-              </div>
-            ))}
-          </div>
-        </section>
-        {/* TODO : スタート時は投稿数が少ないことからページネーションは後で実装 */}
-        {/* <section className="mt-4">
-          <UI.Pagination elementName="#tabs" adjust={-20} />
-        </section> */}
+        <Users.IllustIndex uuid={uuid} />
       </article>
     </>
   );

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -15,13 +15,18 @@ export default function IllustIndex({ uuid }: { uuid: string }) {
 
   useEffect(() => {
     const search = window.location.search;
+    if (
+      (isBookmark && search === "?tab=bookmark") ||
+      (!isBookmark && search === "")
+    )
+      return;
     setIsBookmark(search === "?tab=bookmark");
     setUrl(
       search === "?tab=bookmark"
         ? `/users/${uuid}/bookmarks`
         : `/users/${uuid}/postsIllust`
     );
-  }, [uuid]);
+  }, [uuid, window.location.search]);
 
   useEffect(() => {
     setUrl(

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { IndexIllustData } from "@/types";
+import * as Users from ".";
+import { Illust } from "@/components/features/illusts";
+import { GetFromAPI } from "@/lib";
+import useSWR from "swr";
+import { useEffect, useState } from "react";
+
+const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
+
+export default function IllustIndex({ uuid }: { uuid: string }) {
+  const [isBookmark, setIsBookmark] = useState<boolean>(false);
+  const [url, setUrl] = useState<string>(`/users/${uuid}/postsIllust`);
+
+  useEffect(() => {
+    const search = window.location.search;
+    setIsBookmark(search === "?tab=bookmark");
+    setUrl(
+      search === "?tab=bookmark"
+        ? `/users/${uuid}/bookmarks`
+        : `/users/${uuid}/postsIllust`
+    );
+  }, [uuid]);
+
+  useEffect(() => {
+    setUrl(
+      isBookmark ? `/users/${uuid}/bookmarks` : `/users/${uuid}/postsIllust`
+    );
+  }, [isBookmark, uuid]);
+
+  const { data, error } = useSWR(url, fetcher);
+
+  if (error) return <div>failed to load</div>;
+  if (!data) return;
+
+  const illusts = data.map(
+    (illust: {
+      uuid: string;
+      title: string;
+      data: string;
+      publish_state?: string;
+    }) => {
+      return {
+        uuid: illust.uuid,
+        title: illust.title,
+        image: illust.data,
+        publishRange: illust.publish_state ?? null,
+      };
+    }
+  );
+  return (
+    <>
+      <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
+        <Users.UserTabs
+          userUuid={uuid}
+          isBookmark={isBookmark}
+          setIsBookmark={setIsBookmark}
+        />
+      </section>
+      <section className="container my-2 m-auto">
+        <div className="grid grid-cols-2 md:mx-auto md:grid-cols-4 mx-2 gap-1">
+          {illusts.map((illust: IndexIllustData) => (
+            <div key={illust.uuid}>
+              <Illust illust={illust} />
+            </div>
+          ))}
+        </div>
+      </section>
+      {/* TODO : スタート時は投稿数が少ないことからページネーションは後で実装 */}
+      {/* <section className="mt-4">
+          <UI.Pagination elementName="#tabs" adjust={-20} />
+        </section> */}
+    </>
+  );
+}

--- a/front/src/components/features/users/index.ts
+++ b/front/src/components/features/users/index.ts
@@ -1,5 +1,6 @@
 import UserTabs from "./userTabs";
 import UserEdit from "./edit";
 import Profile from "./profile";
+import IllustIndex from "./illustIndex";
 
-export { UserTabs, UserEdit, Profile };
+export { UserTabs, UserEdit, Profile, IllustIndex };

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -1,12 +1,12 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as Mantine from "@mantine/core";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/lib";
 import { RouterPath } from "@/settings";
 
 enum Tab {
-  post = "myPage",
+  post = "post",
   bookmark = "bookmark",
 }
 
@@ -24,6 +24,10 @@ export default function UserTabs({
   );
   const t_UserPage = useTranslations("UserPage");
   const router = useRouter();
+
+  useEffect(() => {
+    setValue(isBookmark ? Tab.bookmark : Tab.post);
+  }, [isBookmark]);
 
   const handleChange = (newValue: string | null) => {
     if (newValue === value) return;

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -2,42 +2,60 @@
 import { useState } from "react";
 import * as Mantine from "@mantine/core";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/lib";
+import { RouterPath } from "@/settings";
 
 enum Tab {
   post = "myPage",
   bookmark = "bookmark",
 }
 
-export default function UserTabs() {
-  const [value, setValue] = useState<string | null>(Tab.post);
+export default function UserTabs({
+  userUuid,
+  isBookmark,
+  setIsBookmark,
+}: {
+  userUuid: string;
+  isBookmark: boolean;
+  setIsBookmark: (value: boolean) => void;
+}) {
+  const [value, setValue] = useState<string | null>(
+    isBookmark ? Tab.bookmark : Tab.post
+  );
   const t_UserPage = useTranslations("UserPage");
+  const router = useRouter();
 
   const handleChange = (newValue: string | null) => {
     if (newValue === value) return;
 
-    if (newValue === null) {
-      setValue(Tab.post);
-      return;
+    switch (newValue) {
+      case Tab.post:
+        router.push(RouterPath.users(userUuid), { scroll: false });
+        setValue(Tab.post);
+        setIsBookmark(false);
+        break;
+      case Tab.bookmark:
+        router.push(RouterPath.bookmark(userUuid), { scroll: false });
+        setValue(Tab.bookmark);
+        setIsBookmark(true);
+        break;
+      default:
+        router.push(RouterPath.users(userUuid), { scroll: false });
+        setValue(Tab.post);
+        setIsBookmark(false);
+        break;
     }
-    setValue(newValue as Tab);
   };
 
   return (
-    <Mantine.Tabs value={value} onChange={handleChange}>
-      <Mantine.Tabs.List
-        aria-label="一覧切り替え"
-        className="before:border-none"
-      >
-        <Mantine.Tabs.Tab
-          value={Tab.post}
-          className="border-green-400 transition-all hover:bg-transparent cursor-default"
-        >
+    <Mantine.Tabs value={value} onChange={handleChange} color="rgb(74 222 128)">
+      <Mantine.Tabs.List aria-label="一覧切り替え">
+        <Mantine.Tabs.Tab value={Tab.post} className="transition-all">
           {t_UserPage("post")}
         </Mantine.Tabs.Tab>
-        {/* TODO : ブックマーク機能を追加したら追加 */}
-        {/* <Mantine.Tabs.Tab value={Tab.bookmark}>
+        <Mantine.Tabs.Tab value={Tab.bookmark} className="transition-all">
           {t_UserPage("bookmark")}
-        </Mantine.Tabs.Tab> */}
+        </Mantine.Tabs.Tab>
       </Mantine.Tabs.List>
     </Mantine.Tabs>
   );

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -151,7 +151,7 @@ export function AccountMenu({
   const router = useRouter();
 
   const handleLink = (path: string) => {
-    router.push(`/${path}`);
+    router.push(`${path}`);
   };
 
   return (
@@ -205,12 +205,12 @@ export function AccountMenu({
         >
           {t_Menu("myPage")}
         </Mantine.Menu.Item>
-        {/* <Mantine.Menu.Item
+        <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.bookmark(user.uuid))}
           leftSection={<FaRegBookmark />}
         >
           {t_Menu("bookmark")}
-        </Mantine.Menu.Item> */}
+        </Mantine.Menu.Item>
         <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.account)}
           leftSection={<IoMdSettings />}

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -15,5 +15,5 @@ export const RouterPath = {
   illustEdit: (uuid: string) => `/illusts/${uuid}/edit`,
   users: (uuid: string) => `/users/${uuid}`,
   account: "/account",
-  bookmark: (uuid: string) => `/users/${uuid}?bookmark=true`,
+  bookmark: (uuid: string) => `/users/${uuid}?tab=bookmark`,
 };


### PR DESCRIPTION
# 概要
ブックマーク一覧を表示するようにしました。

## 実装項目
- [x] そのユーザーがブックマークしているイラストを取得できること
- [ ] イラストに付随するユーザー名やidを取得できること
   ⇨必要か検討中
- [x] イラストに付随するイラストidを取得できること
- [x] イラストの公開状態が**全体公開以外は取得できない**こと
- [ ] ログインユーザーがイラストを投稿したユーザーの**フォロワーでないとき、イラストを取得できない**こと
   ⇨フォロー機能を追加後に追加
- [ ] 件数が一定以上のときはページネーションを追加するのでそのページに表示する分だけ取得できること
   ⇨初期段階は投稿数が少ないのであとに実装

## 追加実装
- [x] ヘッダーメニューにブックマークページの遷移を追加しました（PCのみ）

## 挙動
<img src="https://i.gyazo.com/3b026da00619aeeeee38e6df2a038901.gif" width="400px" />