### PR TITLE
【feature】下書き状態の編集時に画像の複数枚投稿・編集 close #180

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < Api::V1::BasesController
-  skip_before_action :authenticate_api_v1_user!, only: %i[show bookmarks]
+  skip_before_action :authenticate_api_v1_user!, only: %i[show postsIllust bookmarks]
   before_action :set_user, only: %i[show postsIllust bookmarks]
 
   def show
@@ -11,11 +11,9 @@ class Api::V1::UsersController < Api::V1::BasesController
     # ログインユーザーと表示ユーザーが同じ場合は全ての投稿を取得
     if(current_api_v1_user && current_api_v1_user.uuid == @user.uuid)
       posts = @user.posts.publish_at_desc.map do |post|
-        content = []
+        content = nil
         if post.illust?
-          post.postable.image.each do |image|
-            content << url_for(image)
-          end
+          content = url_for(post.postable.get_first_image)
         end
         {
           uuid: post.short_uuid,
@@ -28,11 +26,9 @@ class Api::V1::UsersController < Api::V1::BasesController
       # ログインユーザーと表示ユーザーが異なる場合は公開投稿のみ取得
       # TODO : フォロワーの場合はフォロワー公開も取得
       posts = @user.posts.only_publish.publish_at_desc.map do |post|
-        content = []
+        content = nil
         if post.illust?
-          post.postable.image.each do |image|
-            content << url_for(image)
-          end
+          content = url_for(post.postable.get_first_image)
         end
         {
           uuid: post.short_uuid,
@@ -58,7 +54,7 @@ class Api::V1::UsersController < Api::V1::BasesController
       {
         uuid: post.short_uuid,
         title:post.title,
-        data: post.illust? ? url_for(post.postable.image) : nil,
+        data: post.illust? ? url_for(post.postable.get_first_image) : nil,
       }
     end
 

--- a/back/app/models/bookmark.rb
+++ b/back/app/models/bookmark.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id         :bigint           not null, primary key
+#  user_uuid  :uuid             not null
+#  post_uuid  :uuid             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Bookmark < ApplicationRecord
   belongs_to :user, primary_key: :uuid, foreign_key: :user_uuid
   belongs_to :post, primary_key: :uuid, foreign_key: :post_uuid

--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -12,43 +12,79 @@ class Illust < ApplicationRecord
   has_many :illust_attachments, -> {order(:position)}, dependent: :destroy
   has_many_attached :image
 
-  def active_storage_upload(data_images)
+  def illust_images_update!(data_images)
+    transaction do
+      begin
+        updated_image = []
+        data_images.each_with_index do |data_image, index|
+          if data_image[:body].start_with?('http')
+            # 既存の画像を検索し、順番が変わっている場合は更新
+            illust_attachment = illust_attachments.find_by(position: data_image[:position])
+            if illust_attachment && illust_attachment.position != index + 1
+              illust_attachment.update!(position: index + 1)
+            end
+            updated_image << illust_attachment
+          else
+            updated_image << illust_image_create!(data_image[:body], index)
+          end
+        end
+
+        # 更新ファイルにないものを削除
+        if updated_image.present?
+          illust_attachments.where.not(id: updated_image.map(&:id)).destroy_all
+        end
+
+        true
+      rescue => e
+        Rails.logger.error("画像の保存に失敗しました: #{e.message}")
+        false
+      end
+    end
+  end
+
+  def illust_images_create!(data_images)
     begin
       data_images.each_with_index do |data_image, index|
-        if data_image.start_with?('http')
-          # URLからBlobを取得
-          blob = ActiveStorage::Blob.find_by(service_url: data_image)
-          illust_attachment = IllustAttachment.find_or_initialize_by(image: blob)
-          illust_attachment.update!(position: index + 1)
-        else
-          # 送信されるデータは data: から始まるためエンコードデータのみ抽出
-          base64_data = data_image
-          if base64_data.start_with?('data:image')
-            base64_data = data_image.split(",")[1]
-          end
-          decoded_image = Base64.decode64(base64_data)
-          # MiniMagickでwebpに軽量化
-          img = MiniMagick::Image.read(decoded_image)
-          img.format 'webp'
-
-          blob = ActiveStorage::Blob.create_and_upload!(
-            io: StringIO.new(img.to_blob),
-            filename: SecureRandom.uuid,
-            content_type: 'image/webp'
-            )
-          illust_attachments.create!(image: blob, position: index + 1)
+        unless illust_image_create!(data_image[:body], index)
+          raise StandardError
+          return false
         end
       end
       true
     rescue => e
-      Rails.logger.error(e)
+      Rails.logger.error(e.message)
+      Rails.logger.error(e.backtrace.join("\n"))
       false
     end
   end
 
+  def illust_image_create!(data_image, index)
+    # 送信されるデータは data: から始まるためエンコードデータのみ抽出
+    base64_data = data_image
+    if base64_data.start_with?('data:image')
+      base64_data = data_image.split(",")[1]
+    end
+    decoded_image = Base64.decode64(base64_data)
+    # MiniMagickでwebpに軽量化
+    img = MiniMagick::Image.read(decoded_image)
+    img.format 'webp'
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(img.to_blob),
+      filename: SecureRandom.uuid,
+      content_type: 'image/webp'
+      )
+    illust_attachment = illust_attachments.create!(position: index + 1)
+    illust_attachment.image.attach(blob)
+    illust_attachment.save!
+    illust_attachment
+  end
+
   def get_first_image
-    Rails.logger.debug("illust_attachments:")
-    Rails.logger.debug(illust_attachments)
-    illust_attachments.first.image
+    if illust_attachments.present?
+      illust_attachments.first.image
+    else
+      raise StandardError, "画像がありません"
+    end
   end
 end

--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -9,26 +9,46 @@
 #
 class Illust < ApplicationRecord
   has_one :post, as: :postable, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_many :illust_attachments, -> {order(:position)}, dependent: :destroy
   has_many_attached :image
 
   def active_storage_upload(data_images)
-    data_images.each do |data_image|
-      # 送信されるデータは data: から始まるためエンコードデータのみ抽出
-      base64_data = data_image
-      if data_image.start_with?('data:image')
-        base64_data = data_image.split(",")[1]
-      end
-      decoded_image = Base64.decode64(base64_data)
-      # MiniMagickでwebpに軽量化
-      img = MiniMagick::Image.read(decoded_image)
-      img.format 'webp'
+    begin
+      data_images.each_with_index do |data_image, index|
+        if data_image.start_with?('http')
+          # URLからBlobを取得
+          blob = ActiveStorage::Blob.find_by(service_url: data_image)
+          illust_attachment = IllustAttachment.find_or_initialize_by(image: blob)
+          illust_attachment.update!(position: index + 1)
+        else
+          # 送信されるデータは data: から始まるためエンコードデータのみ抽出
+          base64_data = data_image
+          if base64_data.start_with?('data:image')
+            base64_data = data_image.split(",")[1]
+          end
+          decoded_image = Base64.decode64(base64_data)
+          # MiniMagickでwebpに軽量化
+          img = MiniMagick::Image.read(decoded_image)
+          img.format 'webp'
 
-      blob = ActiveStorage::Blob.create_and_upload!(
-        io: StringIO.new(img.to_blob),
-        filename: SecureRandom.uuid,
-        content_type: 'image/webp'
-      )
-      image.attach(blob)
+          blob = ActiveStorage::Blob.create_and_upload!(
+            io: StringIO.new(img.to_blob),
+            filename: SecureRandom.uuid,
+            content_type: 'image/webp'
+            )
+          illust_attachments.create!(image: blob, position: index + 1)
+        end
+      end
+      true
+    rescue => e
+      Rails.logger.error(e)
+      false
     end
+  end
+
+  def get_first_image
+    Rails.logger.debug("illust_attachments:")
+    Rails.logger.debug(illust_attachments)
+    illust_attachments.first.image
   end
 end

--- a/back/app/models/illust_attachment.rb
+++ b/back/app/models/illust_attachment.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: illust_attachments
+#
+#  id         :bigint           not null, primary key
+#  illust_id  :bigint           not null
+#  position   :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class IllustAttachment < ApplicationRecord
+  belongs_to :illust
+  has_one_attached :image
+  validates :position, presence: true
+end

--- a/back/db/migrate/20240603043856_create_illust_attachments.rb
+++ b/back/db/migrate/20240603043856_create_illust_attachments.rb
@@ -1,0 +1,9 @@
+class CreateIllustAttachments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :illust_attachments do |t|
+      t.references :illust, null: false, foreign_key: true
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_29_081804) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_03_043856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -67,6 +67,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_29_081804) do
     t.uuid "post_uuid", null: false
     t.index ["post_uuid"], name: "index_favorites_on_post_uuid"
     t.index ["user_uuid"], name: "index_favorites_on_user_uuid"
+  end
+
+  create_table "illust_attachments", force: :cascade do |t|
+    t.bigint "illust_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["illust_id"], name: "index_illust_attachments_on_illust_id"
   end
 
   create_table "illusts", force: :cascade do |t|
@@ -188,6 +196,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_29_081804) do
   add_foreign_key "bookmarks", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "favorites", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "favorites", "users", column: "user_uuid", primary_key: "uuid"
+  add_foreign_key "illust_attachments", "illusts"
   add_foreign_key "post_game_systems", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "synalios"

--- a/back/db/scripts/migrate_existing_images.rb
+++ b/back/db/scripts/migrate_existing_images.rb
@@ -1,0 +1,8 @@
+# 既存のイラストデータを新しいモデルに移行するスクリプト
+Illust.find_each do |illust|
+  illust.image.each_with_index do |image, index|
+    illust_attachment = illust.illust_attachments.build(position: index + 1)
+    illust_attachment.image.attach(image.blob)
+    illust_attachment.save!
+  end
+end

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -124,7 +124,10 @@
     "title": "イラスト編集",
     "illustPostAttention": "一度公開したイラストは変更できません",
     "upload": "イラストアップロード",
-    "uploadValid": "イラストをアップロードしてください"
+    "uploadValid": "イラストをアップロードしてください",
+    "countValid": "投稿できる枚数は12枚までです",
+    "maxSize": "※ファイルサイズは10MBまでです",
+    "maxCount": "※最大12枚までアップロードできます"
   },
   "PostGeneral": {
     "title": "タイトル",

--- a/front/src/app/[locale]/illusts/[uuid]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/edit/page.tsx
@@ -14,6 +14,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { FaImage } from "rocketicons/fa";
 import useSWR, { mutate } from "swr";
 import { XShare } from "@/components/features/illusts";
+import { IoMdClose } from "rocketicons/io";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -73,6 +74,7 @@ export default function IllustEditPage({
   const CAPTION_MAX_LENGTH = 10000;
   const MEGA_BITE = 1024 ** 2;
   const MAX_SIZE = 10 * MEGA_BITE;
+  const MAX_COUNT = 12;
 
   const form = useForm({
     initialValues: {
@@ -198,12 +200,16 @@ export default function IllustEditPage({
   };
 
   const handleDrop = (files: File[]) => {
-    // TODO : 一枚のみ対応、後々複数枚対応する
-    const reader = new FileReader();
-    reader.onload = () => {
-      setPostIllust([reader.result as string]);
-    };
-    reader.readAsDataURL(files[0]);
+    for (const file of files) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (e.target) {
+          postIllust.push(e.target.result as string);
+          form.setValues({ postIllust: postIllust });
+        }
+      };
+      reader.readAsDataURL(file);
+    }
   };
 
   const handleModalClose = () => {
@@ -246,40 +252,56 @@ export default function IllustEditPage({
                       {t_PostIllustEdit("upload")}
                       <span className="text-red-600">*</span>
                     </label>
-                    <Dropzone
-                      name="postIllust"
-                      onDrop={(files) => handleDrop(files)}
-                      maxSize={MAX_SIZE}
-                      accept={IMAGE_MIME_TYPE}
-                      style={{
-                        height: mobile ? "15rem" : "30rem",
-                        width: "auto",
-                        margin: "0 auto",
-                        position: "relative",
-                        cursor: "pointer",
-                      }}
-                      {...form.getInputProps("postIllust")}
-                    >
-                      <Dropzone.Idle>
-                        {postIllust.length > 0 && (
+                    <div className="w-full bg-slate-400 p-5 rounded grid grid-cols-2 gap-4 md:grid-cols-4">
+                      {postIllust.map((image: string, i: number) => (
+                        <div
+                          className="relative w-full h-full max-h-28 flex justify-center items-center"
+                          key={i}
+                        >
+                          <Mantine.Button
+                            className="absolute -top-3 -right-3 rounded-full bg-white transition-all h-6 w-6 p-0 border border-red-400 hover:bg-red-400"
+                            onClick={() => {
+                              postIllust.splice(i, 1);
+                              form.setValues({ postIllust: postIllust });
+                            }}
+                          >
+                            <IoMdClose className="icon-red-sm p-0" />
+                          </Mantine.Button>
                           <Mantine.Image
-                            src={postIllust[0]}
-                            h={mobile ? "15rem" : "30rem"}
-                            w="auto"
-                            m="auto"
-                            fit="cover"
-                            className="opacity-50"
+                            src={image}
+                            key={i}
+                            className="object-cover w-full h-full rounded"
                           />
-                        )}
-                        <FaImage
-                          className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                        </div>
+                      ))}
+                      {postIllust.length < MAX_COUNT && (
+                        <Dropzone
+                          name="postIllust"
+                          multiple
+                          onDrop={(files) => handleDrop(files)}
+                          maxSize={MAX_SIZE}
+                          accept={IMAGE_MIME_TYPE}
                           style={{
-                            width: "3rem",
-                            height: "3rem",
+                            position: "relative",
+                            cursor: "pointer",
+                            borderRadius: "4px",
+                            height: "110px",
+                            border: "2px dashed rgb(148 163 184)",
                           }}
-                        />
-                      </Dropzone.Idle>
-                    </Dropzone>
+                          {...form.getInputProps("postIllust")}
+                        >
+                          <Dropzone.Idle>
+                            <FaImage
+                              className="icon-black opacity-50 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                              style={{
+                                width: "3rem",
+                                height: "3rem",
+                              }}
+                            />
+                          </Dropzone.Idle>
+                        </Dropzone>
+                      )}
+                    </div>
                     {form.errors.postIllust && (
                       <p className="text-sm text-red-500">
                         {form.errors.postIllust}
@@ -289,13 +311,20 @@ export default function IllustEditPage({
                 ) : (
                   <>
                     {postIllust.length > 0 && (
-                      <Mantine.Image
-                        src={postIllust[0]}
-                        h={mobile ? "15rem" : "30rem"}
-                        w="auto"
-                        m="auto"
-                        fit="cover"
-                      />
+                      <div className="w-full bg-slate-400 p-5 rounded grid grid-cols-2 gap-4 md:grid-cols-4">
+                        {postIllust.map((image: string, i: number) => (
+                          <div
+                            className="relative w-full h-full max-h-28 flex justify-center items-center"
+                            key={i}
+                          >
+                            <Mantine.Image
+                              src={image}
+                              key={i}
+                              className="object-cover w-full h-full rounded"
+                            />
+                          </div>
+                        ))}
+                      </div>
                     )}
                     <p className="text-center text-sm">
                       ※{t_PostIllustEdit("illustPostAttention")}

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -4,7 +4,7 @@ import { XShare } from "@/components/features/illusts";
 import { GetFromAPI, Post2API, useRouter } from "@/lib";
 import { userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
-import { IPublicState } from "@/types";
+import { IPublicState, IEditIllust } from "@/types";
 import * as Mantine from "@mantine/core";
 import { Dropzone, IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
@@ -50,7 +50,7 @@ export default function IllustPostPage() {
 
   const form = useForm({
     initialValues: {
-      postIllust: [] as string[],
+      postIllust: [] as IEditIllust[],
       title: "",
       caption: "",
       publishRange: "" as IPublicState,
@@ -58,7 +58,7 @@ export default function IllustPostPage() {
       gameSystem: "",
     },
     validate: {
-      postIllust: (value) => {
+      postIllust: (value: IEditIllust[]) => {
         if (value.length === 0) {
           return t_PostIllust("uploadValid");
         } else if (value.length > MAX_COUNT) {
@@ -145,7 +145,7 @@ export default function IllustPostPage() {
       const reader = new FileReader();
       reader.onload = (e) => {
         if (e.target) {
-          postIllust.push(e.target.result as string);
+          postIllust.push({ body: e.target.result as string, position: -1 });
           form.setValues({ postIllust: postIllust });
         }
       };
@@ -209,7 +209,7 @@ export default function IllustPostPage() {
                   <div className="w-full bg-slate-400 p-5 rounded grid grid-cols-2 gap-4 md:grid-cols-4">
                     {form
                       .getValues()
-                      .postIllust.map((image: string, i: number) => (
+                      .postIllust.map((image: IEditIllust, i: number) => (
                         <div
                           className="relative w-full h-full max-h-28 flex justify-center items-center"
                           key={i}
@@ -225,7 +225,7 @@ export default function IllustPostPage() {
                             <IoMdClose className="icon-red-sm p-0" />
                           </Mantine.Button>
                           <Mantine.Image
-                            src={image}
+                            src={image.body}
                             key={i}
                             className="object-cover w-full h-full rounded"
                           />

--- a/front/src/app/[locale]/illusts/post/page.tsx
+++ b/front/src/app/[locale]/illusts/post/page.tsx
@@ -34,7 +34,6 @@ export default function IllustPostPage() {
   );
   const theme = Mantine.useMantineTheme();
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
-  const [postIllust, setPostIllust] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [postUuid, setPostUuid] = useState<string>("");
   const [modalOpen, setModalOpen] = useState(false);
@@ -51,7 +50,7 @@ export default function IllustPostPage() {
 
   const form = useForm({
     initialValues: {
-      postIllust: postIllust,
+      postIllust: [] as string[],
       title: "",
       caption: "",
       publishRange: "" as IPublicState,
@@ -59,10 +58,10 @@ export default function IllustPostPage() {
       gameSystem: "",
     },
     validate: {
-      postIllust: () => {
-        if (postIllust.length === 0) {
+      postIllust: (value) => {
+        if (value.length === 0) {
           return t_PostIllust("uploadValid");
-        } else if (postIllust.length > MAX_COUNT) {
+        } else if (value.length > MAX_COUNT) {
           return t_PostIllust("countValid");
         }
       },
@@ -100,8 +99,14 @@ export default function IllustPostPage() {
   if (disableData()) return <div>Now Loading</div>;
 
   const handleSubmit = async () => {
-    const { title, caption, publishRange, synalioTitle, gameSystem } =
-      form.getValues();
+    const {
+      title,
+      postIllust,
+      caption,
+      publishRange,
+      synalioTitle,
+      gameSystem,
+    } = form.getValues();
     const post = {
       post: {
         postable_attributes: postIllust,
@@ -135,6 +140,7 @@ export default function IllustPostPage() {
   };
 
   const handleDrop = (files: File[]) => {
+    const postIllust = form.values.postIllust;
     for (const file of files) {
       const reader = new FileReader();
       reader.onload = (e) => {
@@ -173,7 +179,7 @@ export default function IllustPostPage() {
                 </label>
                 <p className="text-sm">{t_PostIllust("maxSize")}</p>
                 <p className="text-sm">{t_PostIllust("maxCount")}</p>
-                {postIllust.length === 0 ? (
+                {form.getValues().postIllust.length === 0 ? (
                   <Dropzone
                     name="postIllust"
                     multiple
@@ -201,28 +207,31 @@ export default function IllustPostPage() {
                   </Dropzone>
                 ) : (
                   <div className="w-full bg-slate-400 p-5 rounded grid grid-cols-2 gap-4 md:grid-cols-4">
-                    {postIllust.map((image: string, i: number) => (
-                      <div
-                        className="relative w-full h-full max-h-28 flex justify-center items-center"
-                        key={i}
-                      >
-                        <Mantine.Button
-                          className="absolute -top-3 -right-3 rounded-full bg-white transition-all h-6 w-6 p-0 border border-red-400 hover:bg-red-400"
-                          onClick={() => {
-                            postIllust.splice(i, 1);
-                            form.setValues({ postIllust: postIllust });
-                          }}
-                        >
-                          <IoMdClose className="icon-red-sm p-0" />
-                        </Mantine.Button>
-                        <Mantine.Image
-                          src={image}
+                    {form
+                      .getValues()
+                      .postIllust.map((image: string, i: number) => (
+                        <div
+                          className="relative w-full h-full max-h-28 flex justify-center items-center"
                           key={i}
-                          className="object-cover w-full h-full rounded"
-                        />
-                      </div>
-                    ))}
-                    {postIllust.length < MAX_COUNT && (
+                        >
+                          <Mantine.Button
+                            className="absolute -top-3 -right-3 rounded-full bg-white transition-all h-6 w-6 p-0 border border-red-400 hover:bg-red-400"
+                            onClick={() => {
+                              let postIllust = form.getValues().postIllust;
+                              postIllust.splice(i, 1);
+                              form.setValues({ postIllust: postIllust });
+                            }}
+                          >
+                            <IoMdClose className="icon-red-sm p-0" />
+                          </Mantine.Button>
+                          <Mantine.Image
+                            src={image}
+                            key={i}
+                            className="object-cover w-full h-full rounded"
+                          />
+                        </div>
+                      ))}
+                    {form.getValues().postIllust.length < MAX_COUNT && (
                       <Dropzone
                         name="postIllust"
                         multiple

--- a/front/src/components/features/illusts/illust.tsx
+++ b/front/src/components/features/illusts/illust.tsx
@@ -29,7 +29,7 @@ export default function Illust({
       case IPublicState.All:
         return "全体公開";
       case IPublicState.Draft:
-        return "非公開";
+        return "下書き";
       case IPublicState.URL:
         return "URLを知っている人";
       case IPublicState.Private:

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -22,11 +22,16 @@ export interface IndexIllustData {
   publishRange?: string;
 }
 
+export interface IEditIllust {
+  body: string;
+  position: number;
+}
+
 export interface IEditIllustData {
   uuid: string;
   title: string;
   caption?: string;
-  image?: string[];
+  image?: IEditIllust[];
   tags?: string[];
   synalio?: string;
   publish_state: IPublicState;


### PR DESCRIPTION
# 概要
下書き状態での編集時に、イラストの複数枚投稿および更新をできるようにしました。

## 実装項目
- [x] 編集画面で下書き状態だったときは画像の複数枚投稿ができること
- [x] 複数枚画像がプレビューに出ているとき、任意の画像を削除できること
- [x] 複数枚画像がプレビューに出ているとき、すべての画像を削除できること

## 挙動
[こちら](https://i.gyazo.com/9fec21ed8bcca496e95a1406eaaac587.mp4)からご確認いただけます。

## 補足
ActiveStrageには順序などのカラムが存在しないため、順序を保管するように別途テーブルを用意しました。
下記の狙いがあります
- 漫画など順番があるものをいずれ自由に入れ替えられるようにするため
- 投稿済みの画像で順番が変わるだけだった場合、再度アップロードするより使い回すほうがDBの動きが少なくなる＝更新速度の向上するのではないかと考えたため