### PR TITLE
【hotfix】投稿と下書き保存時のエラーの対応

### DIFF
--- a/back/app/models/illust.rb
+++ b/back/app/models/illust.rb
@@ -8,7 +8,7 @@
 #  updated_at :datetime         not null
 #
 class Illust < ApplicationRecord
-  has_one :post, as: :postable, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_one :post, as: :postable, foreign_key: :user_uuid, dependent: :destroy
   has_many :illust_attachments, -> {order(:position)}, dependent: :destroy
   has_many_attached :image
 

--- a/back/app/models/post_game_system.rb
+++ b/back/app/models/post_game_system.rb
@@ -9,7 +9,7 @@
 #  post_uuid      :uuid             not null
 #
 class PostGameSystem < ApplicationRecord
-  belongs_to :post, foreign_key: :post_uuid
+  belongs_to :post, foreign_key: :post_uuid, primary_key: :uuid
   # NOTE : ActiveHashの関連付けはこれ以下のものに適応されるようなので、
   #        ActiveHashの関連付けでないものは上に書く
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/back/app/models/post_synalio.rb
+++ b/back/app/models/post_synalio.rb
@@ -9,6 +9,6 @@
 #  post_uuid  :uuid             not null
 #
 class PostSynalio < ApplicationRecord
-  belongs_to :post, foreign_key: :post_uuid
+  belongs_to :post, foreign_key: :post_uuid, primary_key: :uuid
   belongs_to :synalio
 end

--- a/back/app/models/post_tag.rb
+++ b/back/app/models/post_tag.rb
@@ -9,6 +9,6 @@
 #  post_uuid  :uuid             not null
 #
 class PostTag < ApplicationRecord
-  belongs_to :post, foreign_key: :post_uuid
+  belongs_to :post, foreign_key: :post_uuid, primary_key: :uuid
   belongs_to :tag
 end

--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -11,6 +11,6 @@
 #  user_uuid    :uuid             not null
 #
 class Profile < ApplicationRecord
-  belongs_to :user, foreign_key: :user_uuid
+  belongs_to :user, foreign_key: :user_uuid, primary_key: :uuid
   validates :text, length: { maximum: 250 }
 end

--- a/back/app/models/relationship.rb
+++ b/back/app/models/relationship.rb
@@ -9,6 +9,6 @@
 #  followed_uuid :uuid             not null
 #
 class Relationship < ActiveRecord::Base
-  belongs_to :follower, class_name: 'User', inverse_of: :following_relationships,foreign_key: :follower_uuid
-  belongs_to :followed, class_name: 'User', inverse_of: :follower_relationships, foreign_key: :followed_uuid
+  belongs_to :follower, class_name: 'User', inverse_of: :following_relationships,foreign_key: :follower_uuid, primary_key: :uuid
+  belongs_to :followed, class_name: 'User', inverse_of: :follower_relationships, foreign_key: :followed_uuid, primary_key: :uuid
 end

--- a/back/app/models/synalio.rb
+++ b/back/app/models/synalio.rb
@@ -9,5 +9,6 @@
 #
 class Synalio < ApplicationRecord
   has_many :post_synalios, dependent: :destroy
+  has_many :posts, primary_key: :uuid, foreign_key: :post_uuid, through: :post_synalios
   validates :name, presence: true, uniqueness: true
 end

--- a/back/app/models/tag.rb
+++ b/back/app/models/tag.rb
@@ -9,6 +9,6 @@
 #
 class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
-  has_many :posts, primary_key: :uuid, foreign_key: :post_uuid, through: :post_tags
+  has_many :posts, foreign_key: :post_uuid, through: :post_tags
   validates :name, presence: true, uniqueness: true
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -21,22 +21,22 @@ class User < ActiveRecord::Base
         :recoverable, :rememberable, :validatable,
         :omniauthable, omniauth_providers: %i[google_oauth2 discord]
   include DeviseTokenAuth::Concerns::User
-  has_many :authentications, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
-  has_one :profile, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
-  has_many :user_notices, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_many :authentications, foreign_key: :user_uuid, dependent: :destroy
+  has_one :profile, foreign_key: :user_uuid, dependent: :destroy
+  has_many :user_notices, foreign_key: :user_uuid, dependent: :destroy
   has_many :notices, through: :user_notices
-  has_many :posts, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_many :posts, foreign_key: :user_uuid, dependent: :destroy
 
   # フォローしている人とフォローされている人を取得するためのアソシエーション
-  has_many :following_relationships, class_name: 'Relationship', primary_key: :uuid, foreign_key: 'follower_uuid', dependent: :destroy, inverse_of: :follower
-  has_many :follower_relationships, class_name: 'Relationship', primary_key: :uuid, foreign_key: 'followed_uuid', dependent: :destroy, inverse_of: :followed
+  has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_uuid', dependent: :destroy, inverse_of: :follower
+  has_many :follower_relationships, class_name: 'Relationship', foreign_key: 'followed_uuid', dependent: :destroy, inverse_of: :followed
   # フォローしている人を呼び出す
   has_many :following, through: :following_relationships, source: :followed
   # フォロワーを呼びたす
   has_many :followers, through: :follower_relationships, source: :follower
 
-  has_many :favorites, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
-  has_many :bookmarks, primary_key: :uuid, foreign_key: :user_uuid, dependent: :destroy
+  has_many :favorites, foreign_key: :user_uuid, dependent: :destroy
+  has_many :bookmarks, foreign_key: :user_uuid, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
   enum role: { general: 0, admin: 1 } # general: 一般ユーザー, admin: 管理者

--- a/back/app/models/user_notice.rb
+++ b/back/app/models/user_notice.rb
@@ -10,7 +10,7 @@
 #  user_uuid   :uuid             not null
 #
 class UserNotice < ApplicationRecord
-  belongs_to :user, foreign_key: :user_uuid
+  belongs_to :user, foreign_key: :user_uuid, primary_key: :uuid
   belongs_to :notice
   enum notice_kind: { app: 0, email: 1 }
 end

--- a/back/config/locales/ja.yml
+++ b/back/config/locales/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        post:
+          attributes:
+            post_synalios:
+              invalid: "無効なシナリオです"
+            post_tags:
+              invalid: "無効なタグです"
+            postable:
+              required: "投稿タイプを設定してください"
+            post_game_systems:
+              invalid: "無効なゲームシステムです"

--- a/front/src/app/[locale]/illusts/[uuid]/edit/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/edit/page.tsx
@@ -351,8 +351,8 @@ export default function IllustEditPage({
                 setIsDeleteConfirmation(event.target.checked)
               }
               deleteConfirmationError={deleteConfirmationError}
-              handleDeleteSubmit={() => handleDeleteSubmit}
-              handleBack={() => handleBack}
+              handleDeleteSubmit={handleDeleteSubmit}
+              handleBack={handleBack}
             />
           ) : form.values.publishRange === IPublicState.Draft ? (
             <Post.DraftModal onClick={handleModalClose} />

--- a/front/src/components/features/post/deleteModal.tsx
+++ b/front/src/components/features/post/deleteModal.tsx
@@ -12,7 +12,7 @@ export default function DeleteModal({
   isDeleteConfirmation: boolean;
   setIsDeleteConfirmation: ChangeEventHandler<HTMLInputElement>;
   deleteConfirmationError: string;
-  handleDeleteSubmit: ()=>void;
+  handleDeleteSubmit: () => void;
   handleBack: () => void;
 }) {
   const t_EditGeneral = useTranslations("EditGeneral");


### PR DESCRIPTION
# 概要
投稿時と下書き保存時に正常に保存できないエラーが発生したので修正しました。

## 補足
idをuuidに変更したことによる不具合のようです。
postを先にcreateしuuidを確定させてからアソシエーションを結んでる関連データを保存するように修正しています。

## メモ
uuidに変えたことによる弊害なのでなにか良い方法がないか模索してみます。