### PR TITLE
【feature】ユーザーページ更新 close #34 #35

### DIFF
--- a/back/app/controllers/api/v1/auth/token_validations_controller.rb
+++ b/back/app/controllers/api/v1/auth/token_validations_controller.rb
@@ -3,9 +3,15 @@ class Api::V1::Auth::TokenValidationsController < DeviseTokenAuth::TokenValidati
   protected
 
   def render_validate_token_success
+
+    avatar_url = nil
+    if @resource.profile.present? && @resource.profile.avatar.attached?
+      avatar_url = url_for(@resource.profile.avatar)
+    end
+
     render json: {
       success: true,
-      user: @resource.as_header_json
+      user: @resource.as_header_json(avatar_url)
     }
   end
 end

--- a/back/app/controllers/api/v1/bases_controller.rb
+++ b/back/app/controllers/api/v1/bases_controller.rb
@@ -1,10 +1,20 @@
 class Api::V1::BasesController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
   before_action :authenticate_api_v1_user!
+  before_action :set_url_options
 
   protected
 
   def resource_name
     :user
+  end
+
+  private
+
+  def set_url_options
+    ActiveStorage::Current.url_options = {
+      host: request.base_url,
+      protocol: request.scheme
+    }
   end
 end

--- a/back/app/controllers/api/v1/profiles_controller.rb
+++ b/back/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::ProfilesController < Api::V1::BasesController
+  def update
+    begin
+      user = current_api_v1_user
+      if user.profile.nil?
+        user.build_profile
+      end
+      user.profile.save_header_image(profile_params[:header_image]) if profile_params[:header_image]
+      user.profile.save_avatar(profile_params[:avatar]) if profile_params[:avatar]
+      user.profile.text = profile_params[:text] if profile_params[:text]
+      user.profile.save!
+      head :ok
+    rescue => e
+      Rails.logger.error(e.message)
+      render json: { error: e.message }, status: :bad_request
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:header_image, :avatar, :text)
+  end
+end

--- a/back/app/controllers/api/v1/profiles_controller.rb
+++ b/back/app/controllers/api/v1/profiles_controller.rb
@@ -9,7 +9,8 @@ class Api::V1::ProfilesController < Api::V1::BasesController
       user.profile.save_avatar(profile_params[:avatar]) if profile_params[:avatar]
       user.profile.text = profile_params[:text] if profile_params[:text]
       user.profile.save!
-      head :ok
+      avater = user.profile.avatar.attached? ? url_for(user.profile.avatar) : nil
+      render json: {avater: avater}, status: :ok
     rescue => e
       Rails.logger.error(e.message)
       render json: { error: e.message }, status: :bad_request

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,18 @@ class Api::V1::UsersController < Api::V1::BasesController
   before_action :set_user, only: %i[show postsIllust bookmarks]
 
   def show
-    render json: @user.as_custom_json, status: :ok
+    header_image_url = nil
+    avatar_url = nil
+    if @user.profile.present?
+      if@user.profile.header_image.attached?
+        header_image_url = url_for(@user.profile.header_image)
+      end
+      if @user.profile.avatar.attached?
+        avatar_url = url_for(@user.profile.avatar)
+      end
+    end
+
+    render json: @user.as_custom_json(header_image_url,avatar_url), status: :ok
   end
 
   def postsIllust

--- a/back/app/models/link.rb
+++ b/back/app/models/link.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: links
+#
+#  id         :bigint           not null, primary key
+#  user_uuid  :uuid             not null
+#  link_kind  :integer          not null
+#  content    :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Link < ApplicationRecord
+  belongs_to :user, primary_key: :uuid, foreign_key: :user_uuid
+  enum link_kind: { twitter: 0, pixiv: 1, fusetter: 2, privatter: 3, other: 4}
+
+  def self.set_links(user_uuid, links)
+    links.each do |link_kind, link_url|
+      Rails.logger.info("link_kind: #{link_kind}, link_url: #{link_url}")
+      if link_url.blank?
+        Link.find_by(user_uuid: user_uuid, link_kind: link_kind)&.destroy
+        next
+      end
+      link = Link.find_by(user_uuid: user_uuid, link_kind: link_kind)
+      link_content = get_content_id(link_kind, link_url)
+      if link
+        link.update(content: link_content)
+      else
+        Link.create(user_uuid: user_uuid, link_kind: link_kind, content: link_content)
+      end
+    end
+  end
+
+  def self.get_links(user_uuid)
+    links = Link.where(user_uuid: user_uuid)
+    {
+      twitter: links.find_by(link_kind: :twitter)&.content,
+      pixiv: links.find_by(link_kind: :pixiv)&.content,
+      fusetter: links.find_by(link_kind: :fusetter)&.content,
+      privatter: links.find_by(link_kind: :privatter)&.content,
+      other: links.find_by(link_kind: :other)&.content
+    }
+  end
+
+  private
+
+  def self.get_content_id(link_kind, link_url)
+    if link_kind == Link.link_kinds[:other]
+      link_url
+    else
+      link_url.split('/').last
+    end
+  end
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -213,7 +213,7 @@ class Post < ApplicationRecord
         name: user.name,
         profile: user.profile&.text,
         avatar: user.profile&.avatar&.url,
-        follower: user.followers.count
+        links: Link.get_links(user.uuid),
       },
       publish_state: publish_state,
       published_at: published_at.strftime('%Y/%m/%d %H:%M:%S'),

--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -13,4 +13,55 @@
 class Profile < ApplicationRecord
   belongs_to :user, foreign_key: :user_uuid, primary_key: :uuid
   validates :text, length: { maximum: 250 }
+
+  has_one_attached :header_image
+  has_one_attached :avatar
+
+  # ヘッダー画像の保存
+  def save_header_image(image)
+    transaction do
+      begin
+        blob = get_blob(image)
+        header_image.attach(blob)
+        true
+      rescue => e
+        Rails.logger.error("ヘッダー画像の保存に失敗しました: #{e.message}")
+        false
+      end
+    end
+  end
+
+  def save_avatar(image)
+    transaction do
+      begin
+        blob = get_blob(image)
+        avatar.attach(blob)
+        true
+      rescue => e
+        Rails.logger.error("アバター画像の保存に失敗しました: #{e.message}")
+        false
+      end
+    end
+  end
+
+  def get_blob(image)
+    # URLの場合は保存しない
+    return true if image.start_with?('http')
+
+    base64_data = image
+    if base64_data.start_with?('data:image')
+      base64_data = image.split(",")[1]
+    end
+
+    decoded_image = Base64.decode64(base64_data)
+    # MiniMagickでwebpに軽量化
+    img = MiniMagick::Image.read(decoded_image)
+    img.format 'webp'
+
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(img.to_blob),
+      filename: SecureRandom.uuid,
+      content_type: 'image/webp'
+    )
+  end
 end

--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -12,7 +12,7 @@
 #
 class Profile < ApplicationRecord
   belongs_to :user, foreign_key: :user_uuid, primary_key: :uuid
-  validates :text, length: { maximum: 250 }
+  validates :text, length: { maximum: 1000 }
 
   has_one_attached :header_image
   has_one_attached :avatar

--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -19,27 +19,25 @@ class Profile < ApplicationRecord
 
   # ヘッダー画像の保存
   def save_header_image(image)
+    return if image.blank? || image.start_with?('http')
     transaction do
       begin
         blob = get_blob(image)
         header_image.attach(blob)
-        true
       rescue => e
         Rails.logger.error("ヘッダー画像の保存に失敗しました: #{e.message}")
-        false
       end
     end
   end
 
   def save_avatar(image)
+    return if image.blank? || image.start_with?('http')
     transaction do
       begin
         blob = get_blob(image)
         avatar.attach(blob)
-        true
       rescue => e
         Rails.logger.error("アバター画像の保存に失敗しました: #{e.message}")
-        false
       end
     end
   end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -101,12 +101,12 @@ class User < ActiveRecord::Base
     }
   end
 
-  def as_custom_json(posts = [])
+  def as_custom_json(header_image_url, avatar_url)
     {
       uuid: short_uuid,
       name: name,
-      avatar: profile&.avatar&.url,
-      header_image: profile&.header_image&.url,
+      avatar: avatar_url,
+      header_image: header_image_url,
       profile: profile&.text,
       following_count: following.count || 0,
       follower_count: followers.count || 0,

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -90,12 +90,11 @@ class User < ActiveRecord::Base
     nil
   end
 
-  def as_header_json
+  def as_header_json(avatar_url)
     {
       uuid: short_uuid,
       name: name,
-      avatar: profile&.avatar&.url,
-      header_image: profile&.header_image&.url,
+      avatar: avatar_url,
       following_count: following.count || 0,
       follower_count: followers.count || 0,
     }

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   has_many :authentications, foreign_key: :user_uuid, dependent: :destroy
   has_one :profile, foreign_key: :user_uuid, dependent: :destroy
+  has_many :links, foreign_key: :user_uuid, dependent: :destroy
   has_many :user_notices, foreign_key: :user_uuid, dependent: :destroy
   has_many :notices, through: :user_notices
   has_many :posts, foreign_key: :user_uuid, dependent: :destroy
@@ -109,6 +110,7 @@ class User < ActiveRecord::Base
       profile: profile&.text,
       following_count: following.count || 0,
       follower_count: followers.count || 0,
+      links: Link.get_links(uuid),
     }
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         member do
           get 'bookmarks'
           get 'postsIllust'
+          resource :profile, only: %i[update]
         end
       end
       resources :favorites, only: %i[show create destroy]

--- a/back/db/migrate/20240605094722_create_links.rb
+++ b/back/db/migrate/20240605094722_create_links.rb
@@ -1,0 +1,12 @@
+class CreateLinks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :links do |t|
+      t.uuid :user_uuid, null: false
+      t.integer :link_kind, null: false
+      t.string :content, null: false
+      t.timestamps
+    end
+    add_foreign_key :links, :users, column: :user_uuid, primary_key: :uuid
+    add_index :links, %i[user_uuid link_kind content], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_043856) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_094722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -81,6 +81,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_043856) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "links", force: :cascade do |t|
+    t.uuid "user_uuid", null: false
+    t.integer "link_kind", null: false
+    t.string "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_uuid", "link_kind", "content"], name: "index_links_on_user_uuid_and_link_kind_and_content", unique: true
   end
 
   create_table "notices", force: :cascade do |t|
@@ -197,6 +206,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_043856) do
   add_foreign_key "favorites", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "favorites", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "illust_attachments", "illusts"
+  add_foreign_key "links", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "post_game_systems", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "synalios"

--- a/front/src/app/[locale]/illusts/[uuid]/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/page.tsx
@@ -381,7 +381,7 @@ export default function IllustPage({
                     />
                     <span className="text-xl">{data.user.name}</span>
                   </Lib.Link>
-                  <div className="w-full flex flex-col gap-2 justify-center items-center">
+                  {/* <div className="w-full flex flex-col gap-2 justify-center items-center">
                     {follow ? (
                       <Mantine.Button
                         variant="outlined"
@@ -401,7 +401,7 @@ export default function IllustPage({
                         {t_ShowPost("follow")}
                       </Mantine.Button>
                     )}
-                  </div>
+                  </div> */}
                 </>
               ) : (
                 <Mantine.Skeleton height={70} />

--- a/front/src/app/[locale]/illusts/[uuid]/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/page.tsx
@@ -21,10 +21,7 @@ export default function IllustPage({
 }: {
   params: { uuid: string };
 }) {
-  const { data: illustData, error: illustError } = useSWR(
-    `/posts/${uuid}`,
-    fetcherIllust
-  );
+  const { data, error } = useSWR(`/posts/${uuid}`, fetcherIllust);
   const user = useRecoilValue(RecoilState.userState);
   const [expansionMode, setExpansionMode] = useState(false);
   const [openCaption, setOpenCaption] = useState(false);
@@ -38,15 +35,15 @@ export default function IllustPage({
   const router = Lib.useRouter();
 
   useEffect(() => {
-    if (illustError) {
-      if (illustError.response.status === 404) {
+    if (error) {
+      if (error.response.status === 404) {
         router.push(RouterPath.notFound);
       } else {
         router.push(RouterPath.error);
       }
       return;
     }
-  }, [illustError]);
+  }, [error]);
 
   const handleOpenUser = () => {
     // TODO : 投稿者の情報モーダルの表示
@@ -81,9 +78,9 @@ export default function IllustPage({
         <div className="flex flex-col gap-8 md:w-full">
           <div>
             <section className="bg-gray-400 max-h-[90vh] w-full flex justify-center items-center mb-4 overflow-hidden">
-              {illustData ? (
+              {data ? (
                 <>
-                  {illustData.data.length === 1 ? (
+                  {data.data.length === 1 ? (
                     <Mantine.Button
                       variant={mobile ? "transparent" : "filled"}
                       color={mobile ? "transparent" : "gray"}
@@ -93,8 +90,8 @@ export default function IllustPage({
                       style={{ width: "100%", padding: 0 }}
                     >
                       <Mantine.Image
-                        src={illustData.data[0]}
-                        alt={illustData.title}
+                        src={data.data[0]}
+                        alt={data.title}
                         fit="contain"
                         style={{
                           width: "100%",
@@ -112,7 +109,7 @@ export default function IllustPage({
                       dragFree
                       withIndicators
                     >
-                      {illustData.data.map((img: string, i: number) => (
+                      {data.data.map((img: string, i: number) => (
                         <Carousel.Slide key={i}>
                           <Mantine.Button
                             variant={mobile ? "transparent" : "filled"}
@@ -124,7 +121,7 @@ export default function IllustPage({
                           >
                             <Mantine.Image
                               src={img}
-                              alt={illustData.title}
+                              alt={data.title}
                               fit="contain"
                               style={{
                                 width: "100%",
@@ -144,8 +141,8 @@ export default function IllustPage({
                     padding="sm"
                   >
                     <Mantine.Image
-                      src={illustData.data[clickImage]}
-                      alt={illustData.title}
+                      src={data.data[clickImage]}
+                      alt={data.title}
                       fit="contain"
                       style={{
                         maxHeight: "80vh",
@@ -161,18 +158,16 @@ export default function IllustPage({
             <section className="bg-white p-4 rounded flex flex-col gap-3">
               <div className="flex flex-col gap-3">
                 <div className="flex flex-col gap-2">
-                  {illustData ? (
+                  {data ? (
                     <>
                       <IconButtonList
                         postUuid={uuid}
-                        publicState={illustData?.publish_state}
-                        title={illustData?.title}
-                        postUserUuid={illustData?.user?.uuid}
+                        publicState={data?.publish_state}
+                        title={data?.title}
+                        postUserUuid={data?.user?.uuid}
                       />
 
-                      <h3 className="text-2xl font-semibold">
-                        {illustData?.title}
-                      </h3>
+                      <h3 className="text-2xl font-semibold">{data?.title}</h3>
                       <Mantine.Button
                         variant="transparent"
                         onClick={handleOpenUser}
@@ -183,10 +178,10 @@ export default function IllustPage({
                           radius="xl"
                           size="md"
                           alt="icon"
-                          src={illustData.user.avatar}
+                          src={data.user.avatar}
                         />
                         <span className="ml-2 text-black">
-                          {illustData.user.name}
+                          {data.user.name}
                         </span>
                       </Mantine.Button>
                     </>
@@ -202,26 +197,26 @@ export default function IllustPage({
                     </>
                   )}
                   <div className="text-sm flex justify-center items-center md:justify-start gap-2">
-                    {illustData ? (
+                    {data ? (
                       <>
-                        {illustData.game_systems && (
+                        {data.game_systems && (
                           <Lib.Link
                             href={RouterPath.illustSearch(
-                              `gameSystem=${illustData.game_systems}`
+                              `gameSystem=${data.game_systems}`
                             )}
                             className="bg-blue-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                           >
-                            {illustData.game_systems}
+                            {data.game_systems}
                           </Lib.Link>
                         )}
-                        {illustData.synalio && (
+                        {data.synalio && (
                           <Lib.Link
                             href={RouterPath.illustSearch(
-                              `synalioName=${illustData.synalio}`
+                              `synalioName=${data.synalio}`
                             )}
                             className="bg-green-200 rounded-lg px-2 py-1 hover:opacity-60 transition-all"
                           >
-                            {illustData.synalio}
+                            {data.synalio}
                           </Lib.Link>
                         )}
                       </>
@@ -234,8 +229,8 @@ export default function IllustPage({
                     )}
                   </div>
                   <div className="flex flex-wrap gap-2 text-sm">
-                    {illustData ? (
-                      illustData.tags.map((tag: string, i: number) => (
+                    {data ? (
+                      data.tags.map((tag: string, i: number) => (
                         <Lib.Link
                           key={i}
                           href={RouterPath.illustSearch(`tags=${tag}`)}
@@ -252,9 +247,9 @@ export default function IllustPage({
                       </>
                     )}
                   </div>
-                  {illustData ? (
+                  {data ? (
                     <p className="flex justify-end items-center text-xs text-gray-500 md:gap-4">
-                      {illustData.published_at}
+                      {data.published_at}
                     </p>
                   ) : (
                     <div className="flex justify-end items-center">
@@ -264,20 +259,19 @@ export default function IllustPage({
                 </div>
               </div>
               <div className="relative w-full">
-                {illustData ? (
+                {data ? (
                   <>
                     <p
                       className={`overflow-y-hidden
                 ${
-                  openCaption ||
-                  illustData.caption.length <= CAPTION_OPEN_LENGTH
+                  openCaption || data.caption.length <= CAPTION_OPEN_LENGTH
                     ? "max-h-auto"
                     : `gradientText max-h-32`
                 }`}
                     >
-                      {illustData.caption}
+                      {data.caption}
                     </p>
-                    {illustData.caption.length > CAPTION_OPEN_LENGTH && (
+                    {data.caption.length > CAPTION_OPEN_LENGTH && (
                       <button
                         type="button"
                         className={`w-full bg-blue-300 border border-blue-600 border-opacity-50 bg-opacity-50 hover:bg-opacity-25 hover:border-opacity-25 flex justify-center items-center rounded py-1 transition-all
@@ -346,7 +340,7 @@ export default function IllustPage({
                     className="flex gap-4 items-start py-4 border-b border-slate-200 last-of-type:border-none"
                   >
                     <Lib.Link href="/users/1">
-                      <Mantine.Avatar alt="icon" src={illustData.user.avatar} />
+                      <Mantine.Avatar alt="icon" src={data.user.avatar} />
                     </Lib.Link>
                     <div className="flex flex-col gap-1">
                       <Lib.Link href="/users/1" className="font-semibold">
@@ -371,70 +365,95 @@ export default function IllustPage({
         <article className="hidden md:w-1/3 md:block md:sticky md:top-4">
           <section className="bg-white p-4 rounded flex flex-col gap-4">
             <h3 className="text-xl">{t_ShowPost("postUser")}</h3>
-            <div className="flex gap-4 justify-start items-center">
-              {illustData ? (
+            <div className="flex flex-col w-full gap-2 justify-center items-center">
+              {data ? (
                 <>
-                  <Lib.Link href={RouterPath.users(illustData.user.uuid)}>
+                  <Lib.Link
+                    href={RouterPath.users(data.user.uuid)}
+                    className="flex gap-2 items-center rounded transition-all w-full p-2 hover:bg-slate-300"
+                  >
                     <Mantine.Avatar
                       variant="default"
                       radius="xl"
                       size="lg"
                       alt="icon"
-                      src={illustData.user.avatar}
+                      src={data.user.avatar}
                     />
+                    <span className="text-xl">{data.user.name}</span>
                   </Lib.Link>
-                  <div className="w-full flex flex-col gap-2">
-                    <Lib.Link
-                      href={RouterPath.users(illustData.user.uuid)}
-                      className="text-xl"
-                    >
-                      {illustData.user.name}
-                    </Lib.Link>
-                    {/* {follow ? (
-                  <Mantine.Button
-                    variant="outlined"
-                    size="small"
-                    onClick={handleFollow}
-                    className="w-32"
-                  >
-                    {t_ShowPost("unFollow")}
-                  </Mantine.Button>
-                ) : (
-                  <Mantine.Button
-                    variant="contained"
-                    size="small"
-                    onClick={handleFollow}
-                    className="w-32"
-                  >
-                    {t_ShowPost("follow")}
-                  </Mantine.Button>
-                )} */}
+                  <div className="w-full flex flex-col gap-2 justify-center items-center">
+                    {follow ? (
+                      <Mantine.Button
+                        variant="outlined"
+                        size="small"
+                        onClick={handleFollow}
+                        className="w-32"
+                      >
+                        {t_ShowPost("unFollow")}
+                      </Mantine.Button>
+                    ) : (
+                      <Mantine.Button
+                        variant="contained"
+                        size="small"
+                        onClick={handleFollow}
+                        className="w-32"
+                      >
+                        {t_ShowPost("follow")}
+                      </Mantine.Button>
+                    )}
                   </div>
                 </>
               ) : (
                 <Mantine.Skeleton height={70} />
               )}
             </div>
-            {/* <div className="flex flex-wrap gap-3">
-              <Lib.Link href="" className="bg-slate-300 rounded px-2">
-                X
-              </Lib.Link>
-              <Lib.Link href="" className="bg-slate-300 rounded px-2">
-                pixiv
-              </Lib.Link>
-              <Lib.Link href="" className="bg-slate-300 rounded px-2">
-                privatter
-              </Lib.Link>
-              <Lib.Link href="" className="bg-slate-300 rounded px-2">
-                {t_ShowPost("fusetter")}
-              </Lib.Link>
-              <Lib.Link href="" className="bg-slate-300 rounded px-2">
-                {t_ShowPost("other")}
-              </Lib.Link>
-            </div> */}
+            {data?.user?.links && (
+              <div className="flex flex-wrap gap-3">
+                {data.user.links.twitter && (
+                  <a
+                    href={`https://x.com/${data.user.links.twitter}`}
+                    className="bg-slate-300 rounded px-2 hover:bg-slate-500 hover:text-white transition-all"
+                  >
+                    X
+                  </a>
+                )}
+                {data.user.links.twitter && (
+                  <a
+                    href={`https://www.pixiv.net/users/${data.user.links.twitter}`}
+                    className="bg-slate-300 rounded px-2 hover:bg-slate-500 hover:text-white transition-all"
+                  >
+                    pixiv
+                  </a>
+                )}
+                {data.user.links.twitter && (
+                  <a
+                    href={`https://fusetter.com/u/${data.user.links.twitter}`}
+                    className="bg-slate-300 rounded px-2 hover:bg-slate-500 hover:text-white transition-all"
+                  >
+                    {t_ShowPost("fusetter")}
+                  </a>
+                )}
+                {data.user.links.twitter && (
+                  <a
+                    href={`https://privatter.net/u/${data.user.links.twitter}`}
+                    className="bg-slate-300 rounded px-2 hover:bg-slate-500 hover:text-white transition-all"
+                  >
+                    privatter
+                  </a>
+                )}
+                {data.user.links.other && (
+                  <a
+                    href={data.user.links.other}
+                    className="bg-slate-300 rounded px-2 hover:bg-slate-500 hover:text-white transition-all"
+                  >
+                    {t_ShowPost("other")}
+                  </a>
+                )}
+              </div>
+            )}
             <div>
-              {illustData ? (
-                <p>{illustData.user.profile}</p>
+              {data ? (
+                <p>{data.user.profile}</p>
               ) : (
                 <Mantine.Skeleton height={35} />
               )}

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -17,7 +17,7 @@ interface UserProfile {
   name: string;
   headerImage: string;
   avatar: string;
-  link: {
+  links: {
     twitter: string;
     pixiv: string;
     fusetter: string;
@@ -53,13 +53,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
       name: data.name,
       headerImage: data.header_image,
       avatar: data.avatar,
-      link: {
-        twitter: "",
-        pixiv: "",
-        fusetter: "",
-        privatter: "",
-        other: "",
-      },
+      links: data.links,
       profile: data.profile,
     });
   }, [data]);
@@ -97,7 +91,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                     src={userProfile.avatar}
                   />
                 ) : (
-                  <Mantine.Skeleton height={150} circle />
+                  <Mantine.Skeleton width={150} height={130} radius="100%" />
                 )}
                 <div className="w-full flex flex-col justify-start items-end md:items-start md:justify-start md:relative">
                   {/* ユーザー編集 */}
@@ -117,12 +111,12 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                   </div>
                   {userProfile ? (
                     <>
-                      {userProfile.link && (
+                      {userProfile.links && (
                         <ul className="flex justify-start items-center mt-auto ml-2 flex-wrap gap-2 md:h-2/3">
-                          {userProfile.link.twitter && (
+                          {userProfile.links.twitter && (
                             <li>
                               <a
-                                href="#"
+                                href={`https://x.com/${userProfile.links.twitter}`}
                                 className="text-white bg-black hover:bg-gray-600 transition-all px-2 py-1 rounded text-sm"
                                 target="_blank"
                               >
@@ -130,10 +124,10 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                               </a>
                             </li>
                           )}
-                          {userProfile.link.pixiv && (
+                          {userProfile.links.pixiv && (
                             <li>
                               <a
-                                href="#"
+                                href={`https://www.pixiv.net/users/${userProfile.links.pixiv}`}
                                 className="text-white bg-sky-400 transition-all hover:bg-sky-700 px-2 py-1 rounded text-sm"
                                 target="_blank"
                               >
@@ -141,10 +135,10 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                               </a>
                             </li>
                           )}
-                          {userProfile.link.fusetter && (
+                          {userProfile.links.fusetter && (
                             <li>
                               <a
-                                href="#"
+                                href={`https://fusetter.com/u/${userProfile.links.fusetter}`}
                                 className="text-white bg-orange-500 bg-opacity-80 hover:bg-orange-800 transition-all px-2 py-1 rounded text-sm"
                                 target="_blank"
                               >
@@ -152,10 +146,10 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                               </a>
                             </li>
                           )}
-                          {userProfile.link.privatter && (
+                          {userProfile.links.privatter && (
                             <li>
                               <a
-                                href="#"
+                                href={`https://privatter.net/u/${userProfile.links.privatter}`}
                                 className="text-white bg-sky-500 transition-all hover:bg-sky-700 px-2 py-1 rounded text-sm"
                                 target="_blank"
                               >
@@ -163,10 +157,10 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                               </a>
                             </li>
                           )}
-                          {userProfile.link.other && (
+                          {userProfile.links.other && (
                             <li>
                               <a
-                                href="#"
+                                href={userProfile.links.other}
                                 className="text-white bg-indigo-400 transition-all hover:bg-indigo-700 px-2 py-1 rounded text-sm"
                                 target="_blank"
                               >

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -7,6 +7,8 @@ import { GetFromAPI, useRouter } from "@/lib";
 import useSWR from "swr";
 import { useEffect, useState } from "react";
 import { RouterPath } from "@/settings";
+import { useRecoilValue } from "recoil";
+import { userState } from "@/recoilState";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -31,6 +33,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
   const { data, error } = useSWR(`/users/${uuid}`, fetcher);
   const [userProfile, setUserProfile] = useState<UserProfile>();
   const router = useRouter();
+  const user = useRecoilValue(userState);
 
   useEffect(() => {
     if (error) {
@@ -98,9 +101,9 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
                 )}
                 <div className="w-full flex flex-col justify-start items-end md:items-start md:justify-start md:relative">
                   {/* ユーザー編集 */}
-                  {/* {userProfile.uuid === user.uuid && (
+                  {userProfile?.uuid === user.uuid && (
                     <Users.UserEdit userProfile={userProfile} />
-                  )} */}
+                  )}
                   <div className="hidden md:block md:h-1/3">
                     {userProfile ? (
                       <h2 className="text-3xl">

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -89,7 +89,7 @@ export default function UserEdit({
       pixiv: (value) => {
         if (
           value &&
-          (!value.match(/^https:\/\/pixiv\.com\/users\/.+$/) ||
+          (!value.match(/^https:\/\/www.pixiv\.net\/users\/.+$/) ||
             !isValidURL(value))
         ) {
           return "有効なURLではありません";
@@ -357,7 +357,7 @@ export default function UserEdit({
                     <dd className="w-full">
                       <MantineCore.Input
                         name="pixiv"
-                        placeholder="https://pixiv.net/..."
+                        placeholder="https://www.pixiv.net/users/..."
                         className="w-full"
                         {...form.getInputProps("pixiv")}
                       />
@@ -376,7 +376,7 @@ export default function UserEdit({
                     <dd className="w-full">
                       <MantineCore.Input
                         name="fusetter"
-                        placeholder="https://fusetter.com/..."
+                        placeholder="https://fusetter.com/u/..."
                         className="w-full"
                         {...form.getInputProps("fusetter")}
                       />
@@ -395,7 +395,7 @@ export default function UserEdit({
                     <dd className="w-full">
                       <MantineCore.Input
                         name="privatter"
-                        placeholder="https://privatter.net/..."
+                        placeholder="https://privatter.net/u/..."
                         className="w-full"
                         {...form.getInputProps("privatter")}
                       />

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { FaImage } from "rocketicons/fa";
 import { useForm } from "@mantine/form";
 import { Put2API } from "@/lib";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import { userState } from "@/recoilState";
 import { mutate } from "swr";
 
@@ -27,7 +27,7 @@ export default function UserEdit({
   const [avatarBlob, setAvatarBlob] = useState(userProfile.avatar);
   const theme = MantineCore.useMantineTheme();
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
-  const user = useRecoilValue(userState);
+  const [user, setUser] = useRecoilState(userState);
 
   const form = useForm({
     mode: "uncontrolled",
@@ -119,6 +119,9 @@ export default function UserEdit({
 
       alert("変更しました");
       mutate(`/users/${user.uuid}`);
+      if (res.data.avatar) {
+        setUser((prev) => ({ ...prev, avatar: res.data.avatar }));
+      }
     } catch (error) {
       alert("エラーが発生しました");
     } finally {

--- a/front/src/components/features/users/edit.tsx
+++ b/front/src/components/features/users/edit.tsx
@@ -72,6 +72,11 @@ export default function UserEdit({
         }
         return null;
       },
+      profile: (value) => {
+        if (value.length > 1000) {
+          return "1000文字以内で入力してください";
+        }
+      },
     },
   });
 

--- a/front/src/components/features/users/profile.tsx
+++ b/front/src/components/features/users/profile.tsx
@@ -2,7 +2,6 @@
 
 import { useDisclosure } from "@mantine/hooks";
 import * as Mantine from "@mantine/core";
-import * as UI from "@/components/ui";
 import { useEffect, useState } from "react";
 
 export default function Profile({ profileText }: { profileText: string }) {
@@ -11,16 +10,17 @@ export default function Profile({ profileText }: { profileText: string }) {
   const MAX_TEXT_LENGTH = 200;
   const MAX_BREAK_COUNT = 2;
 
-  if (!profileText || profileText.length === 0) {
-    return null;
-  }
-
   useEffect(() => {
+    if (!profileText || profileText.length === 0) return;
     const breakCount = profileText.split("\n").length;
     setIsCollapse(
       breakCount > MAX_BREAK_COUNT || profileText.length > MAX_TEXT_LENGTH
     );
   }, [profileText]);
+
+  if (!profileText || profileText.length === 0) {
+    return null;
+  }
 
   return (
     <Mantine.Box className="bg-white p-5 rounded w-full relative">

--- a/front/src/components/features/users/profile.tsx
+++ b/front/src/components/features/users/profile.tsx
@@ -32,17 +32,19 @@ export default function Profile({ profileText }: { profileText: string }) {
       >
         {profileText}
       </Mantine.Text>
-      <button
-        type="button"
-        className={`w-full bg-blue-300 border border-blue-600 border-opacity-50 bg-opacity-50 hover:bg-opacity-25 hover:border-opacity-25 flex justify-center items-center rounded py-1 transition-all ${
-          opened && "mt-3"
-        } `}
-        onClick={toggle}
-      >
-        <span className={`${opened ? "rotate-180" : ""} transition-all`}>
-          ▼
-        </span>
-      </button>
+      {isCollapse && (
+        <button
+          type="button"
+          className={`w-full bg-blue-300 border border-blue-600 border-opacity-50 bg-opacity-50 hover:bg-opacity-25 hover:border-opacity-25 flex justify-center items-center rounded py-1 transition-all ${
+            opened && "mt-3"
+          } `}
+          onClick={toggle}
+        >
+          <span className={`${opened ? "rotate-180" : ""} transition-all`}>
+            ▼
+          </span>
+        </button>
+      )}
     </Mantine.Box>
   );
 }

--- a/front/src/components/features/users/profile.tsx
+++ b/front/src/components/features/users/profile.tsx
@@ -3,26 +3,46 @@
 import { useDisclosure } from "@mantine/hooks";
 import * as Mantine from "@mantine/core";
 import * as UI from "@/components/ui";
+import { useEffect, useState } from "react";
 
 export default function Profile({ profileText }: { profileText: string }) {
   const [opened, { toggle }] = useDisclosure(false);
+  const [isCollapse, setIsCollapse] = useState(false);
+  const MAX_TEXT_LENGTH = 200;
+  const MAX_BREAK_COUNT = 2;
 
   if (!profileText || profileText.length === 0) {
     return null;
   }
 
+  useEffect(() => {
+    const breakCount = profileText.split("\n").length;
+    setIsCollapse(
+      breakCount > MAX_BREAK_COUNT || profileText.length > MAX_TEXT_LENGTH
+    );
+  }, [profileText]);
+
   return (
-    <Mantine.Box className="bg-white p-5 rounded w-full">
+    <Mantine.Box className="bg-white p-5 rounded w-full relative">
       <Mantine.Text
-        className={`text-lg ${
-          opened ? "text-gray-500 opacity-50" : "gradientText"
+        className={`text-lg whitespace-pre ${
+          opened || !isCollapse ? "max-h-auto" : `gradientText max-h-32`
+        }
         }`}
       >
-        {profileText.slice(0, 140)}...
-      </Mantine.Text>
-      <UI.Collapse opened={opened} toggle={toggle}>
         {profileText}
-      </UI.Collapse>
+      </Mantine.Text>
+      <button
+        type="button"
+        className={`w-full bg-blue-300 border border-blue-600 border-opacity-50 bg-opacity-50 hover:bg-opacity-25 hover:border-opacity-25 flex justify-center items-center rounded py-1 transition-all ${
+          opened && "mt-3"
+        } `}
+        onClick={toggle}
+      >
+        <span className={`${opened ? "rotate-180" : ""} transition-all`}>
+          ▼
+        </span>
+      </button>
     </Mantine.Box>
   );
 }

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -37,14 +37,18 @@ export default function Headers() {
       const uid = params.get("uid");
       const client = params.get("client");
       const expiry = params.get("expiry");
-      if (accessToken && uid && client && expiry) {
+      const isToken = accessToken && uid && client && expiry;
+      if (isToken) {
         setAccessTokens(accessToken, client, uid, expiry);
       }
 
       const result = await autoLogin();
       if (result.success && result.user) {
         setUser(result.user);
-        return;
+      }
+
+      if (isToken) {
+        router.push(RouterPath.home);
       }
     };
     fetchData();

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
+}
+
 /* Googleでログイン・新規登録 */
 .gsi-material-button {
   -moz-user-select: none;

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -2,11 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
-    "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
-}
-
 /* Googleでログイン・新規登録 */
 .gsi-material-button {
   -moz-user-select: none;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -66,7 +66,7 @@ export interface INoticeStates {
 export interface IUserPageEdit {
   headerImage: string;
   avatar: string;
-  link: {
+  links: {
     twitter: string;
     pixiv: string;
     fusetter: string;


### PR DESCRIPTION
# 概要
ユーザーページの更新処理を実装しました。

## 実装項目
バックエンド
- [x] ヘッダー画像を更新できること
- [ ] ヘッダー画像を更新したとき、前のヘッダー画像を削除できること
   ⇨ Misskeyみたいに過去のを選べるようにするのもあり？検討の余地あり
- [x] ヘッダー画像の変更がなかったとき、更新されないこと
- [x] アイコン画像を更新できること
- [ ] アイコン画像を更新したとき、前のアイコン画像を削除できること
   ⇨ Misskeyみたいに過去のを選べるようにするのもあり？検討の余地あり
- [x] アイコン画像が変更がなかったとき、アイコン画像が更新されないこと
- [ ] ユーザー名を更新できること
   ⇨ アカウント設定から変更可能
- [ ] ユーザー名の変更がなかったとき、ユーザー名が更新されないこと
   ⇨ アカウント設定から変更可能
- [x] プロフィールを更新できること
- [ ] プロフィールの変更がなかったとき、プロフィールが変更されないこと
   ⇨ ActiveRecordにおまかせ
- [x] リンクを更新できること
- [x] リンクが空のときデータを削除できること
- [ ] リンクの変更がなかったとき、リンクが更新されないこと

フロント・バックの連携
- [x] 入力データがバックに送れること（アクセスできること）
- [x] 入力データにもとづいで更新されること
- [x] ログインユーザー以外が他のユーザーの編集ができないこと
- [ ] ログインユーザー以外がAPIを直接叩くなどで他のユーザーの編集をしようとしたら「権限がありません」とエラーが表示されること
   ⇨ 認証エラーになるのでなし
- [ ] 保存に成功したら「保存しました」と表示されモーダルが閉じること
   ⇨ 後でトースターなどで実装
- [x] 保存に失敗したら「保存に失敗しました」と表示されること
   ⇨ 現在アラートで表示

## 挙動
[こちら](https://i.gyazo.com/fbf8de7073f60c201b62fedf93d04922.mp4)からご覧いただけます

## 補足
ログイン・ログアウトも含めいくつかはモーダルではなくトースターのほうが煩わしくない気がしています。