### PR TITLE
【fix】SNS認証失敗時の画面遷移 close #186

### DIFF
--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -29,6 +29,10 @@ class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCal
     end
   end
 
+  def failure
+    redirect_to "#{ENV['FRONT_URL']}/ja/auth-failure", allow_other_host: true
+  end
+
   private
 
   # 保存とリダイレクト

--- a/back/config/initializers/devise.rb
+++ b/back/config/initializers/devise.rb
@@ -314,11 +314,12 @@ Devise.setup do |config|
   # OmniAuth
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
     scope: 'email,profile',
-    prompt: 'select_account',
     provider_ignores_state: Rails.env.development?,
+    failure_redirect_url: '/api/v1/auth/failure'
   }
   config.omniauth :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], {
     scope: 'email identify',
     provider_ignores_state: Rails.env.development?,
+    failure_redirect_url: '/api/v1/auth/failure'
   }
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      # ログイン失敗時のリダイレクト
+      get 'auth/sign_in', to: 'auth/omniauth_callbacks#failure'
       mount_devise_token_auth_for 'User', at: 'auth',controllers: {
         omniauth_callbacks: 'api/v1/auth/omniauth_callbacks',
         sessions:           'api/v1/auth/sessions',

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -33,6 +33,7 @@
     "signupWithGoogle": "Googleで登録",
     "signupWithDiscord": "Discordで登録",
     "signupFailed": "登録に失敗しました",
+    "authFailed": "認証に失敗しました",
     "toLogin": "ログインはこちら",
     "toSignUp": "新規登録はこちら",
     "toPasswordReset": "パスワードを忘れた方はこちら",

--- a/front/src/app/[locale]/auth-failure/page.tsx
+++ b/front/src/app/[locale]/auth-failure/page.tsx
@@ -1,0 +1,28 @@
+import { Link } from "@/lib";
+import { RouterPath } from "@/settings";
+import { useTranslations } from "next-intl";
+
+export default function AuthFailurePage() {
+  const t_Auth = useTranslations("Auth");
+  return (
+    <article className="w-full flex flex-col justify-center items-center mb-8">
+      <section className="my-8 flex flex-col justify-center items-center max-w-[448px] w-full px-8 bg-white rounded text-center min-h-32 gap-8">
+        <p>{t_Auth("authFailed")}</p>
+        <div className="flex flex-col gap-2 md:flex-row">
+          <Link
+            href={RouterPath.login}
+            className="text-blue-400 underline hover:text-blue-200 transition-all"
+          >
+            {t_Auth("toSignUp")}
+          </Link>
+          <Link
+            href={RouterPath.login}
+            className="text-blue-400 underline hover:text-blue-200 transition-all"
+          >
+            {t_Auth("toLogin")}
+          </Link>
+        </div>
+      </section>
+    </article>
+  );
+}


### PR DESCRIPTION
# 概要
SNS認証においてキャンセルボタンを押すなど認証をキャンセルしたり失敗した時の画面遷移を実装しました。

## 補足
認証失敗時にRials側のログイン画面に遷移してしまうため、Rails側のログイン画面はすべて認証失敗としフロントへ遷移するようにしてます。
DeviseTokenAuthのコードを読んで失敗時の実装をしたのですが動作しなかったためです。
他に良い方法あったら分かり次第修正します。

## 挙動
<img src="https://i.gyazo.com/91be6cdb3f7ca909461c322cab2f9e0c.gif" width="400px" />