### PR TITLE
【feature】フォロー一覧画面作成（フロントのみ） close #36

### DIFF
--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
         member do
           get 'bookmarks'
           get 'postsIllust'
+          get 'follower'
+          get 'following'
           resource :profile, only: %i[update]
         end
       end

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -109,6 +109,8 @@
   "UserPage": {
     "post": "投稿一覧",
     "bookmark": "ブックマーク一覧",
+    "following": "フォロー中",
+    "follower": "フォロワー",
     "fusetter": "ふせったー",
     "other": "その他",
     "headerImage": "ヘッダー画像",

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -10,6 +10,7 @@ import { RouterPath } from "@/settings";
 import { useRecoilValue } from "recoil";
 import { userState } from "@/recoilState";
 import { Tab } from "@/types";
+import { useSearchParams } from "next/navigation";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -37,6 +38,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
   const [tabType, setTabType] = useState<Tab>(Tab.post);
   const [url, setUrl] = useState<string>(`/users/${uuid}/postsIllust`);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (error) {
@@ -85,48 +87,46 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
   }, []);
 
   useEffect(() => {
-    let newUrl = "";
-    switch (tabType) {
-      case Tab.bookmark:
+    if (!searchParams.get("tab")) {
+      setTabType(Tab.post);
+      setUrl(`/users/${uuid}/postsIllust`);
+      return;
+    }
+    switch (searchParams.get("tab")) {
+      case "bookmark":
         setTabType(Tab.bookmark);
-        newUrl = `/users/${uuid}/bookmarks`;
+        setUrl(`/users/${uuid}/bookmarks`);
         break;
-      case Tab.following:
+      case "following":
         setTabType(Tab.following);
-        newUrl = `/users/${uuid}/following`;
+        setUrl(`/users/${uuid}/following`);
         break;
-      case Tab.follower:
+      case "follower":
         setTabType(Tab.follower);
-        newUrl = `/users/${uuid}/follower`;
+        setUrl(`/users/${uuid}/follower`);
         break;
       default:
         setTabType(Tab.post);
-        newUrl = `/users/${uuid}/postsIllust`;
+        setUrl(`/users/${uuid}/postsIllust`);
         break;
     }
-
-    setUrl(newUrl);
-  }, [uuid, tabType]);
+  }, [searchParams]);
 
   const handleTabChange = (tab: Tab) => {
     switch (tab) {
       case Tab.bookmark:
-        setTabType(Tab.bookmark);
         setUrl(`/users/${uuid}/bookmarks`);
         router.push(RouterPath.bookmark(uuid), { scroll: false });
         break;
       case Tab.following:
-        setTabType(Tab.following);
         setUrl(`/users/${uuid}/following`);
         router.push(RouterPath.following(uuid), { scroll: false });
         break;
       case Tab.follower:
-        setTabType(Tab.follower);
         setUrl(`/users/${uuid}/follower`);
         router.push(RouterPath.follower(uuid), { scroll: false });
         break;
       default:
-        setTabType(Tab.post);
         setUrl(`/users/${uuid}/postsIllust`);
         router.push(RouterPath.users(uuid), { scroll: false });
         break;
@@ -273,7 +273,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
       </article>
 
       {/* タブ */}
-      <article id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
+      <article className="mx-2 md:container md:m-auto md:mb-8">
         <Users.UserTabs
           userUuid={uuid}
           tabType={tabType}

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import * as Users from "@/components/features/users";
 import { GetFromAPI, useRouter } from "@/lib";
 import useSWR from "swr";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RouterPath } from "@/settings";
 import { useRecoilValue } from "recoil";
 import { userState } from "@/recoilState";
@@ -35,8 +35,8 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
   const { data, error } = useSWR(`/users/${uuid}`, fetcher);
   const [userProfile, setUserProfile] = useState<UserProfile>();
   const user = useRecoilValue(userState);
-  const [tabType, setTabType] = useState<Tab>(Tab.post);
-  const [url, setUrl] = useState<string>(`/users/${uuid}/postsIllust`);
+  const tabType = useRef<Tab>(Tab.post);
+  const url = useRef<string>(`/users/${uuid}/postsIllust`);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -112,21 +112,38 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
     }
   }, [searchParams]);
 
+  const setTabType = (tab: Tab) => {
+    tabType.current = tab;
+  };
+
+  const setUrl = (newUrl: string) => {
+    url.current = newUrl;
+  };
+
   const handleTabChange = (tab: Tab) => {
     switch (tab) {
+      case Tab.post:
+        setTabType(Tab.post);
+        setUrl(`/users/${uuid}/postsIllust`);
+        router.push(RouterPath.users(uuid), { scroll: false });
+        break;
       case Tab.bookmark:
+        setTabType(Tab.bookmark);
         setUrl(`/users/${uuid}/bookmarks`);
         router.push(RouterPath.bookmark(uuid), { scroll: false });
         break;
       case Tab.following:
+        setTabType(Tab.following);
         setUrl(`/users/${uuid}/following`);
         router.push(RouterPath.following(uuid), { scroll: false });
         break;
       case Tab.follower:
+        setTabType(Tab.follower);
         setUrl(`/users/${uuid}/follower`);
         router.push(RouterPath.follower(uuid), { scroll: false });
         break;
       default:
+        setTabType(Tab.post);
         setUrl(`/users/${uuid}/postsIllust`);
         router.push(RouterPath.users(uuid), { scroll: false });
         break;
@@ -276,21 +293,22 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
       <article className="mx-2 md:container md:m-auto md:mb-8">
         <Users.UserTabs
           userUuid={uuid}
-          tabType={tabType}
+          tabType={tabType.current}
           handleTabChange={handleTabChange}
         />
       </article>
 
       {/* イラスト一覧 */}
-      {(tabType === Tab.post || tabType === Tab.bookmark) && (
+      {(tabType.current === Tab.post || tabType.current === Tab.bookmark) && (
         <article className="mb-16">
-          <Users.IllustIndex uuid={uuid} url={url} tabType={tabType} />
+          <Users.IllustIndex uuid={uuid} url={url.current} />
         </article>
       )}
       {/* フォロー・フォロワー一覧 */}
-      {(tabType === Tab.following || tabType === Tab.follower) && (
+      {(tabType.current === Tab.following ||
+        tabType.current === Tab.follower) && (
         <article className="mb-16">
-          <Users.FollowIndex uuid={uuid} url={url} tabType={tabType} />
+          <Users.FollowIndex uuid={uuid} url={url.current} />
         </article>
       )}
     </>

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -19,9 +19,15 @@ export default function FollowIndex({
   return (
     <section className="container my-2 m-auto">
       <div className="grid grid-cols-4 md:grid-cols-8 gap-x-2 md:gap-x-0 gap-y-8 mx-2 justify-center items-center">
-        {data.map((user) => (
-          <FollowUser key={user.uuid} user={user} />
-        ))}
+        {data ? (
+          data.map((user, i) => <FollowUser key={i} user={user} />)
+        ) : (
+          <>
+            {Array.from({ length: 10 }, (_, index) => (
+              <FollowUser key={index} />
+            ))}
+          </>
+        )}
       </div>
     </section>
   );

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -1,5 +1,11 @@
+"use client";
+
 import { IIndexFollowData, Tab } from "@/types";
 import { FollowUser } from ".";
+import { GetFromAPI } from "@/lib";
+import useSWR from "swr";
+
+const feature = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function FollowIndex({
   uuid,
@@ -10,23 +16,23 @@ export default function FollowIndex({
   url: string;
   tabType: Tab;
 }) {
-  const data: IIndexFollowData[] = Array.from({ length: 40 }, (_, index) => ({
-    uuid: `uuid-${index}`,
-    name: `User ${index}`,
-    avatar: `avatar-${index}`,
-  }));
+  const { data, error } = useSWR(url, feature);
 
   return (
     <section className="container my-2 m-auto">
       <div className="grid grid-cols-4 md:grid-cols-8 gap-x-2 md:gap-x-0 gap-y-8 mx-2 justify-center items-center">
-        {data ? (
-          data.map((user, i) => <FollowUser key={i} user={user} />)
-        ) : (
+        {data === undefined ? (
           <>
             {Array.from({ length: 10 }, (_, index) => (
               <FollowUser key={index} />
             ))}
           </>
+        ) : (
+          data.users.map(
+            ({ user, i }: { user: IIndexFollowData; i: number }) => (
+              <FollowUser key={i} user={user} />
+            )
+          )
         )}
       </div>
     </section>

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -1,0 +1,28 @@
+import { IIndexFollowData, Tab } from "@/types";
+import { FollowUser } from ".";
+
+export default function FollowIndex({
+  uuid,
+  url,
+  tabType,
+}: {
+  uuid: string;
+  url: string;
+  tabType: Tab;
+}) {
+  const data: IIndexFollowData[] = Array.from({ length: 40 }, (_, index) => ({
+    uuid: `uuid-${index}`,
+    name: `User ${index}`,
+    avatar: `avatar-${index}`,
+  }));
+
+  return (
+    <section className="container my-2 m-auto">
+      <div className="grid grid-cols-4 md:grid-cols-8 gap-x-2 md:gap-x-0 gap-y-8 mx-2 justify-center items-center">
+        {data.map((user) => (
+          <FollowUser key={user.uuid} user={user} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -10,11 +10,9 @@ const feature = (url: string) => GetFromAPI(url).then((res) => res.data);
 export default function FollowIndex({
   uuid,
   url,
-  tabType,
 }: {
   uuid: string;
   url: string;
-  tabType: Tab;
 }) {
   const { data, error } = useSWR(url, feature);
 
@@ -28,7 +26,7 @@ export default function FollowIndex({
             ))}
           </>
         ) : (
-          data.users.map(
+          data.users?.map(
             ({ user, i }: { user: IIndexFollowData; i: number }) => (
               <FollowUser key={i} user={user} />
             )

--- a/front/src/components/features/users/followUser.tsx
+++ b/front/src/components/features/users/followUser.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@/lib";
+import { RouterPath } from "@/settings";
+import { IIndexFollowData } from "@/types";
+import * as Mantine from "@mantine/core";
+
+export default function FollowUser({ user }: { user: IIndexFollowData }) {
+  return (
+    <div>
+      <Link
+        href={RouterPath.users(user.uuid)}
+        className="flex flex-col justify-center items-center"
+      >
+        <Mantine.Avatar
+          variant="default"
+          size="xl"
+          src={user.avatar}
+          alt="avatar"
+        />
+        <p>{user.name}</p>
+      </Link>
+    </div>
+  );
+}

--- a/front/src/components/features/users/followUser.tsx
+++ b/front/src/components/features/users/followUser.tsx
@@ -3,21 +3,38 @@ import { RouterPath } from "@/settings";
 import { IIndexFollowData } from "@/types";
 import * as Mantine from "@mantine/core";
 
-export default function FollowUser({ user }: { user: IIndexFollowData }) {
+export default function FollowUser({
+  user = {
+    uuid: "",
+    name: "",
+    avatar: "",
+  },
+}: {
+  user?: IIndexFollowData;
+}) {
   return (
     <div>
-      <Link
-        href={RouterPath.users(user.uuid)}
-        className="flex flex-col justify-center items-center"
-      >
-        <Mantine.Avatar
-          variant="default"
-          size="xl"
-          src={user.avatar}
-          alt="avatar"
-        />
-        <p>{user.name}</p>
-      </Link>
+      {user.uuid === "" ? (
+        <>
+          <div className="flex flex-col justify-center items-center gap-2">
+            <Mantine.Skeleton width={100} height={100} radius="100%" />
+            <Mantine.Skeleton width={50} height={20} />
+          </div>
+        </>
+      ) : (
+        <Link
+          href={RouterPath.users(user.uuid)}
+          className="flex flex-col justify-center items-center"
+        >
+          <Mantine.Avatar
+            variant="default"
+            size="xl"
+            src={user.avatar}
+            alt="avatar"
+          />
+          <p>{user.name}</p>
+        </Link>
+      )}
     </div>
   );
 }

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -11,11 +11,9 @@ const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function IllustIndex({
   uuid,
-  tabType,
   url,
 }: {
   uuid: string;
-  tabType: Tab;
   url: string;
 }) {
   const [illusts, setIllusts] = useState<IndexIllustData[]>([]);

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -1,45 +1,68 @@
 "use client";
 
-import { IndexIllustData } from "@/types";
+import { IndexIllustData, Tab } from "@/types";
 import * as Users from ".";
 import { Illust } from "@/components/features/illusts";
-import { GetFromAPI } from "@/lib";
+import { GetFromAPI, useRouter } from "@/lib";
 import useSWR from "swr";
 import { useEffect, useState } from "react";
 import { Skeleton } from "@mantine/core";
+import { RouterPath } from "@/settings";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
 export default function IllustIndex({ uuid }: { uuid: string }) {
-  const [isBookmark, setIsBookmark] = useState<boolean>(false);
+  const [tabType, setTabType] = useState<Tab>(Tab.post);
   const [url, setUrl] = useState<string>(`/users/${uuid}/postsIllust`);
   const [illusts, setIllusts] = useState<IndexIllustData[]>([]);
-  const [search, setSearch] = useState<string>("");
   const { data, error } = useSWR(url, fetcher);
+  const router = useRouter();
 
   useEffect(() => {
-    setSearch(window.location.search);
+    let newUrl = "";
+    switch (window.location.search) {
+      case "?tab=bookmark":
+        setTabType(Tab.bookmark);
+        newUrl = `/users/${uuid}/bookmarks`;
+        break;
+      case "?tab=following":
+        setTabType(Tab.following);
+        newUrl = `/users/${uuid}/following`;
+        break;
+      case "?tab=follower":
+        setTabType(Tab.follower);
+        newUrl = `/users/${uuid}/follower`;
+        break;
+      default:
+        setTabType(Tab.post);
+        newUrl = `/users/${uuid}/postsIllust`;
+        break;
+    }
   }, []);
 
   useEffect(() => {
-    if (
-      (isBookmark && search === "?tab=bookmark") ||
-      (!isBookmark && search === "")
-    )
-      return;
-    setIsBookmark(search === "?tab=bookmark");
-    setUrl(
-      search === "?tab=bookmark"
-        ? `/users/${uuid}/bookmarks`
-        : `/users/${uuid}/postsIllust`
-    );
-  }, [uuid, search]);
+    let newUrl = "";
+    switch (tabType) {
+      case Tab.bookmark:
+        setTabType(Tab.bookmark);
+        newUrl = `/users/${uuid}/bookmarks`;
+        break;
+      case Tab.following:
+        setTabType(Tab.following);
+        newUrl = `/users/${uuid}/following`;
+        break;
+      case Tab.follower:
+        setTabType(Tab.follower);
+        newUrl = `/users/${uuid}/follower`;
+        break;
+      default:
+        setTabType(Tab.post);
+        newUrl = `/users/${uuid}/postsIllust`;
+        break;
+    }
 
-  useEffect(() => {
-    setUrl(
-      isBookmark ? `/users/${uuid}/bookmarks` : `/users/${uuid}/postsIllust`
-    );
-  }, [isBookmark, uuid]);
+    setUrl(newUrl);
+  }, [uuid, tabType]);
 
   useEffect(() => {
     if (!data) return;
@@ -62,13 +85,38 @@ export default function IllustIndex({ uuid }: { uuid: string }) {
     );
   }, [data]);
 
+  const handleTabChange = (tab: Tab) => {
+    switch (tab) {
+      case Tab.bookmark:
+        setTabType(Tab.bookmark);
+        setUrl(`/users/${uuid}/bookmarks`);
+        router.push(RouterPath.bookmark(uuid));
+        break;
+      case Tab.following:
+        setTabType(Tab.following);
+        setUrl(`/users/${uuid}/following`);
+        router.push(RouterPath.following(uuid));
+        break;
+      case Tab.follower:
+        setTabType(Tab.follower);
+        setUrl(`/users/${uuid}/follower`);
+        router.push(RouterPath.follower(uuid));
+        break;
+      default:
+        setTabType(Tab.post);
+        setUrl(`/users/${uuid}/postsIllust`);
+        router.push(RouterPath.users(uuid));
+        break;
+    }
+  };
+
   return (
     <>
       <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
         <Users.UserTabs
           userUuid={uuid}
-          isBookmark={isBookmark}
-          setIsBookmark={setIsBookmark}
+          tabType={tabType}
+          handleTabChange={handleTabChange}
         />
       </section>
       <section className="container my-2 m-auto">

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -1,68 +1,25 @@
 "use client";
 
 import { IndexIllustData, Tab } from "@/types";
-import * as Users from ".";
 import { Illust } from "@/components/features/illusts";
-import { GetFromAPI, useRouter } from "@/lib";
+import { GetFromAPI } from "@/lib";
 import useSWR from "swr";
 import { useEffect, useState } from "react";
 import { Skeleton } from "@mantine/core";
-import { RouterPath } from "@/settings";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
-export default function IllustIndex({ uuid }: { uuid: string }) {
-  const [tabType, setTabType] = useState<Tab>(Tab.post);
-  const [url, setUrl] = useState<string>(`/users/${uuid}/postsIllust`);
+export default function IllustIndex({
+  uuid,
+  tabType,
+  url,
+}: {
+  uuid: string;
+  tabType: Tab;
+  url: string;
+}) {
   const [illusts, setIllusts] = useState<IndexIllustData[]>([]);
   const { data, error } = useSWR(url, fetcher);
-  const router = useRouter();
-
-  useEffect(() => {
-    let newUrl = "";
-    switch (window.location.search) {
-      case "?tab=bookmark":
-        setTabType(Tab.bookmark);
-        newUrl = `/users/${uuid}/bookmarks`;
-        break;
-      case "?tab=following":
-        setTabType(Tab.following);
-        newUrl = `/users/${uuid}/following`;
-        break;
-      case "?tab=follower":
-        setTabType(Tab.follower);
-        newUrl = `/users/${uuid}/follower`;
-        break;
-      default:
-        setTabType(Tab.post);
-        newUrl = `/users/${uuid}/postsIllust`;
-        break;
-    }
-  }, []);
-
-  useEffect(() => {
-    let newUrl = "";
-    switch (tabType) {
-      case Tab.bookmark:
-        setTabType(Tab.bookmark);
-        newUrl = `/users/${uuid}/bookmarks`;
-        break;
-      case Tab.following:
-        setTabType(Tab.following);
-        newUrl = `/users/${uuid}/following`;
-        break;
-      case Tab.follower:
-        setTabType(Tab.follower);
-        newUrl = `/users/${uuid}/follower`;
-        break;
-      default:
-        setTabType(Tab.post);
-        newUrl = `/users/${uuid}/postsIllust`;
-        break;
-    }
-
-    setUrl(newUrl);
-  }, [uuid, tabType]);
 
   useEffect(() => {
     if (!data) return;
@@ -85,40 +42,8 @@ export default function IllustIndex({ uuid }: { uuid: string }) {
     );
   }, [data]);
 
-  const handleTabChange = (tab: Tab) => {
-    switch (tab) {
-      case Tab.bookmark:
-        setTabType(Tab.bookmark);
-        setUrl(`/users/${uuid}/bookmarks`);
-        router.push(RouterPath.bookmark(uuid));
-        break;
-      case Tab.following:
-        setTabType(Tab.following);
-        setUrl(`/users/${uuid}/following`);
-        router.push(RouterPath.following(uuid));
-        break;
-      case Tab.follower:
-        setTabType(Tab.follower);
-        setUrl(`/users/${uuid}/follower`);
-        router.push(RouterPath.follower(uuid));
-        break;
-      default:
-        setTabType(Tab.post);
-        setUrl(`/users/${uuid}/postsIllust`);
-        router.push(RouterPath.users(uuid));
-        break;
-    }
-  };
-
   return (
     <>
-      <section id="tabs" className="mx-2 md:container md:m-auto md:mb-8">
-        <Users.UserTabs
-          userUuid={uuid}
-          tabType={tabType}
-          handleTabChange={handleTabChange}
-        />
-      </section>
       <section className="container my-2 m-auto">
         <div className="grid grid-cols-2 md:mx-auto md:grid-cols-4 mx-2 gap-1">
           {data

--- a/front/src/components/features/users/index.ts
+++ b/front/src/components/features/users/index.ts
@@ -2,5 +2,7 @@ import UserTabs from "./userTabs";
 import UserEdit from "./edit";
 import Profile from "./profile";
 import IllustIndex from "./illustIndex";
+import FollowIndex from "./followIndex";
+import FollowUser from "./followUser";
 
-export { UserTabs, UserEdit, Profile, IllustIndex };
+export { UserTabs, UserEdit, Profile, IllustIndex, FollowIndex, FollowUser };

--- a/front/src/components/features/users/profile.tsx
+++ b/front/src/components/features/users/profile.tsx
@@ -26,7 +26,7 @@ export default function Profile({ profileText }: { profileText: string }) {
     <Mantine.Box className="bg-white p-5 rounded w-full relative">
       <Mantine.Text
         className={`text-lg whitespace-pre ${
-          opened || !isCollapse ? "max-h-auto" : `gradientText max-h-32`
+          opened || !isCollapse ? "h-auto" : "gradientText overflow-hidden h-16"
         }
         }`}
       >

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -20,6 +20,10 @@ export default function UserTabs({
   const t_UserPage = useTranslations("UserPage");
   const user = useRecoilValue(userState);
 
+  useEffect(() => {
+    setTab(tabType);
+  }, [tabType]);
+
   const handleChange = (tabName: string | null) => {
     if (!tabName) return;
     setTab(tabName as Tab);

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -1,64 +1,47 @@
 "use client";
-import { useEffect, useState } from "react";
+
 import * as Mantine from "@mantine/core";
 import { useTranslations } from "next-intl";
-import { useRouter } from "@/lib";
-import { RouterPath } from "@/settings";
-
-enum Tab {
-  post = "post",
-  bookmark = "bookmark",
-}
+import { Tab } from "@/types";
+import { useRecoilValue } from "recoil";
+import { userState } from "@/recoilState";
+import { useEffect, useState } from "react";
 
 export default function UserTabs({
   userUuid,
-  isBookmark,
-  setIsBookmark,
+  tabType,
+  handleTabChange,
 }: {
   userUuid: string;
-  isBookmark: boolean;
-  setIsBookmark: (value: boolean) => void;
+  tabType: Tab;
+  handleTabChange: (value: Tab) => void;
 }) {
-  const [value, setValue] = useState<string | null>(
-    isBookmark ? Tab.bookmark : Tab.post
-  );
+  const [tab, setTab] = useState<Tab>(tabType);
   const t_UserPage = useTranslations("UserPage");
-  const router = useRouter();
+  const user = useRecoilValue(userState);
 
-  useEffect(() => {
-    setValue(isBookmark ? Tab.bookmark : Tab.post);
-  }, [isBookmark]);
-
-  const handleChange = (newValue: string | null) => {
-    if (newValue === value) return;
-
-    switch (newValue) {
-      case Tab.post:
-        router.push(RouterPath.users(userUuid), { scroll: false });
-        setValue(Tab.post);
-        setIsBookmark(false);
-        break;
-      case Tab.bookmark:
-        router.push(RouterPath.bookmark(userUuid), { scroll: false });
-        setValue(Tab.bookmark);
-        setIsBookmark(true);
-        break;
-      default:
-        router.push(RouterPath.users(userUuid), { scroll: false });
-        setValue(Tab.post);
-        setIsBookmark(false);
-        break;
-    }
+  const handleChange = (tabName: string | null) => {
+    if (!tabName) return;
+    setTab(tabName as Tab);
+    handleTabChange(tabName as Tab);
   };
 
   return (
-    <Mantine.Tabs value={value} onChange={handleChange} color="rgb(74 222 128)">
+    <Mantine.Tabs value={tab} onChange={handleChange} color="rgb(74 222 128)">
       <Mantine.Tabs.List aria-label="一覧切り替え">
         <Mantine.Tabs.Tab value={Tab.post} className="transition-all">
           {t_UserPage("post")}
         </Mantine.Tabs.Tab>
         <Mantine.Tabs.Tab value={Tab.bookmark} className="transition-all">
           {t_UserPage("bookmark")}
+        </Mantine.Tabs.Tab>
+        {user.uuid === userUuid && (
+          <Mantine.Tabs.Tab value={Tab.following} className="transition-all">
+            {t_UserPage("following")}
+          </Mantine.Tabs.Tab>
+        )}
+        <Mantine.Tabs.Tab value={Tab.follower} className="transition-all">
+          {t_UserPage("follower")}
         </Mantine.Tabs.Tab>
       </Mantine.Tabs.List>
     </Mantine.Tabs>

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -27,7 +27,12 @@ export default function UserTabs({
   };
 
   return (
-    <Mantine.Tabs value={tab} onChange={handleChange} color="rgb(74 222 128)">
+    <Mantine.Tabs
+      value={tab}
+      onChange={handleChange}
+      color="rgb(74 222 128)"
+      className="overflow-x-auto"
+    >
       <Mantine.Tabs.List aria-label="一覧切り替え">
         <Mantine.Tabs.Tab value={Tab.post} className="transition-all">
           {t_UserPage("post")}

--- a/front/src/components/features/users/userTabs.tsx
+++ b/front/src/components/features/users/userTabs.tsx
@@ -16,23 +16,17 @@ export default function UserTabs({
   tabType: Tab;
   handleTabChange: (value: Tab) => void;
 }) {
-  const [tab, setTab] = useState<Tab>(tabType);
   const t_UserPage = useTranslations("UserPage");
   const user = useRecoilValue(userState);
 
-  useEffect(() => {
-    setTab(tabType);
-  }, [tabType]);
-
   const handleChange = (tabName: string | null) => {
     if (!tabName) return;
-    setTab(tabName as Tab);
     handleTabChange(tabName as Tab);
   };
 
   return (
     <Mantine.Tabs
-      value={tab}
+      value={tabType}
       onChange={handleChange}
       color="rgb(74 222 128)"
       className="overflow-x-auto"

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -190,7 +190,7 @@ export function AccountMenu({
         </Mantine.Menu.Item>
         <div className="flex justify-center items-center">
           <Mantine.Menu.Item
-            onClick={() => handleLink(RouterPath.users(user.uuid))}
+            onClick={() => handleLink(RouterPath.following(user.uuid))}
           >
             <div className="flex flex-col justify-center items-center">
               <span className="text-center">{t_Menu("follow")}</span>
@@ -198,7 +198,7 @@ export function AccountMenu({
             </div>
           </Mantine.Menu.Item>
           <Mantine.Menu.Item
-            onClick={() => handleLink(RouterPath.users(user.uuid))}
+            onClick={() => handleLink(RouterPath.follower(user.uuid))}
           >
             <div className="flex flex-col justify-center items-center">
               <span>{t_Menu("follower")}</span>

--- a/front/src/components/layouts/headers.tsx
+++ b/front/src/components/layouts/headers.tsx
@@ -188,7 +188,7 @@ export function AccountMenu({
             <span className="ml-4">{user.name}</span>
           </div>
         </Mantine.Menu.Item>
-        {/* <div className="flex justify-center items-center">
+        <div className="flex justify-center items-center">
           <Mantine.Menu.Item
             onClick={() => handleLink(RouterPath.users(user.uuid))}
           >
@@ -205,7 +205,7 @@ export function AccountMenu({
               <span>{user.follower_count}</span>
             </div>
           </Mantine.Menu.Item>
-        </div> */}
+        </div>
         <Mantine.Menu.Item
           onClick={() => handleLink(RouterPath.users(user.uuid))}
           leftSection={<VscAccount />}

--- a/front/src/settings/index.ts
+++ b/front/src/settings/index.ts
@@ -16,6 +16,8 @@ export const RouterPath = {
   users: (uuid: string) => `/users/${uuid}`,
   account: "/account",
   bookmark: (uuid: string) => `/users/${uuid}?tab=bookmark`,
+  following: (uuid: string) => `/users/${uuid}?tab=following`,
+  follower: (uuid: string) => `/users/${uuid}?tab=follower`,
   error: "/error",
   notFound: "/not-found",
   requestPasswordReset: "/request-password-reset",

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -97,3 +97,9 @@ export enum Tab {
   follower = "follower",
   following = "following",
 }
+
+export interface IIndexFollowData {
+  uuid: string;
+  name: string;
+  avatar: string;
+}

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -90,3 +90,10 @@ export interface AccountProps {
   google_oauth2?: string;
   discord?: string;
 }
+
+export enum Tab {
+  post = "post",
+  bookmark = "bookmark",
+  follower = "follower",
+  following = "following",
+}


### PR DESCRIPTION
# 概要
フォロー一覧・フォロワー一覧画面を作成しました。

## 実装項目
- [x] ユーザーのフォロワー一覧が表示されること
   - [x] ユーザー名が表示されること
   - [x] ユーザーアイコンが表示されること
   - [ ] ユーザー名ないしアイコンからそのユーザーのページに遷移できること
         ⇨バックとの連携後に確認します
- [x] ユーザーのフォロイー一覧が表示されること
   - [x] ユーザー名が表示されること
   - [x] ユーザーアイコンが表示されること
   - [ ] ユーザー名ないしアイコンからそのユーザーのページに遷移できること
         ⇨バックとの連携後に確認します

## 挙動
ダミーデータを入れた時の見た目です
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/01c9d1aa2c45b9be9054f49dc380c147.png" width="450px" /> | <img src="https://i.gyazo.com/dc7300fb541fa301cb62599d1ce9d340.png" width="180px" /> | 