### PR TITLE
【feature】フォロー機能追加 close #148

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::PostsController < Api::V1::BasesController
         end
       end
 
-      render json: post.as_custom_show_json(content), status: :ok
+      render json: post.as_custom_show_json(content, current_api_v1_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: 'Invalid UUID' }, status: :not_found
     rescue ActiveRecord::RecordNotFound => e

--- a/back/app/controllers/api/v1/relationships_controller.rb
+++ b/back/app/controllers/api/v1/relationships_controller.rb
@@ -8,15 +8,16 @@ class Api::V1::RelationshipsController < Api::V1::BasesController
   def create
     user = User.find_by_short_uuid(relationship_params[:user_uuid])
     @relationship = Relationship.new(followed_uuid: user.uuid, follower_uuid: current_api_v1_user.uuid)
-
-    if @relationship.save!
-      head :created
-    else
-      render json: { errors: @relationship.errors.full_messages }, status: :unprocessable_entity
+    begin
+      if @relationship.save!
+        head :created
+      else
+        render json: { errors: @relationship.errors.full_messages }, status: :unprocessable_entity
+      end
+    rescue => e
+      logger.error e
+      render json: { error: e.message }, status: :bad_request
     end
-  rescue => e
-    logger.error e
-    render json: { error: e.message }, status: :bad_request
   end
 
   def destroy

--- a/back/app/controllers/api/v1/relationships_controller.rb
+++ b/back/app/controllers/api/v1/relationships_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::RelationshipsController < Api::V1::BasesController
+  before_action :set_relationship, only: [:show, :destroy]
+
+  def show
+    render json: { isFollowing: @relationship.present? }, status: :ok
+  end
+
+  def create
+    user = User.find_by_short_uuid(relationship_params[:user_uuid])
+    @relationship = Relationship.new(followed_uuid: user.uuid, follower_uuid: current_api_v1_user.uuid)
+
+    if @relationship.save!
+      head :created
+    else
+      render json: { errors: @relationship.errors.full_messages }, status: :unprocessable_entity
+    end
+  rescue => e
+    logger.error e
+    render json: { error: e.message }, status: :bad_request
+  end
+
+  def destroy
+    @relationship.destroy if @relationship.present?
+    head :no_content
+  end
+
+  private
+
+  def set_relationship
+    @relationship = Relationship.find_by(followed_uuid: User.find_by_short_uuid(relationship_params[:id]).uuid, follower_uuid: current_api_v1_user.uuid)
+  end
+
+  def relationship_params
+    params.permit(:id, :user_uuid)
+  end
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -199,7 +199,7 @@ class Post < ApplicationRecord
   end
 
   # 表示用のカスタムjson
-  def as_custom_show_json(content)
+  def as_custom_show_json(content, current_user=nil)
     {
       uuid: short_uuid,
       title: title,

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -91,6 +91,11 @@ class User < ActiveRecord::Base
     nil
   end
 
+  def followed?(other_user_uuid)
+    relationship = following_relationships.find_by(followed_uuid: other_user_uuid)
+    relationship.present?
+  end
+
   def as_header_json(avatar_url)
     {
       uuid: short_uuid,

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
           get 'follower'
           get 'following'
           resource :profile, only: %i[update]
+          resource :relationship, only: %i[show create destroy]
         end
       end
       resources :favorites, only: %i[show create destroy]

--- a/back/db/migrate/20240607044816_remove_unique_index_from_allow_password_change_on_users.rb
+++ b/back/db/migrate/20240607044816_remove_unique_index_from_allow_password_change_on_users.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexFromAllowPasswordChangeOnUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :users, :allow_password_change
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_044816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -196,7 +196,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.boolean "allow_password_change", default: false
-    t.index ["allow_password_change"], name: "index_users_on_allow_password_change", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_sent_at"], name: "index_users_on_reset_password_sent_at", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/front/src/app/[locale]/illusts/[uuid]/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/page.tsx
@@ -16,13 +16,20 @@ import "@mantine/carousel/styles.css";
 const fetcherIllust = (url: string) =>
   Lib.GetFromAPI(url).then((res) => res.data);
 
+const fecherFollow = (url: string) =>
+  Lib.GetFromAPI(url).then((res) => res.data);
+
 export default function IllustPage({
   params: { uuid },
 }: {
   params: { uuid: string };
 }) {
-  const { data, error } = useSWR(`/posts/${uuid}`, fetcherIllust);
   const user = useRecoilValue(RecoilState.userState);
+  const { data, error } = useSWR(`/posts/${uuid}`, fetcherIllust);
+  const { data: followData, error: followError } = useSWR(
+    data?.user?.uuid ? `users/${data.user.uuid}/relationship` : "",
+    fecherFollow
+  );
   const [expansionMode, setExpansionMode] = useState(false);
   const [openCaption, setOpenCaption] = useState(false);
   const [follow, setFollow] = useState(false);
@@ -45,17 +52,35 @@ export default function IllustPage({
     }
   }, [error]);
 
+  useEffect(() => {
+    if (!followData) return;
+    setFollow(followData.isFollowing);
+  }, [followData]);
+
   const handleOpenUser = () => {
     // TODO : 投稿者の情報モーダルの表示
   };
 
-  const handleFollow = () => {
-    // TODO : 未ログインならログイン誘導モーダルを表示
-    setModalOpen(true);
-    return;
-
-    // TODO : フォロー・フォロー解除の処理
-    setFollow(!follow);
+  const handleFollow = async () => {
+    try {
+      if (follow) {
+        const res = await Lib.Delete2API(
+          `users/${data.user.uuid}/relationship`
+        );
+        if (res.status === 204) {
+          setFollow(false);
+        }
+      } else {
+        const res = await Lib.Post2API(`users/${data.user.uuid}/relationship`, {
+          user_uuid: data.user.uuid,
+        });
+        if (res.status === 201) {
+          setFollow(true);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   const handleSendComment = (e: FormEvent) => {
@@ -381,27 +406,29 @@ export default function IllustPage({
                     />
                     <span className="text-xl">{data.user.name}</span>
                   </Lib.Link>
-                  {/* <div className="w-full flex flex-col gap-2 justify-center items-center">
-                    {follow ? (
-                      <Mantine.Button
-                        variant="outlined"
-                        size="small"
-                        onClick={handleFollow}
-                        className="w-32"
-                      >
-                        {t_ShowPost("unFollow")}
-                      </Mantine.Button>
-                    ) : (
-                      <Mantine.Button
-                        variant="contained"
-                        size="small"
-                        onClick={handleFollow}
-                        className="w-32"
-                      >
-                        {t_ShowPost("follow")}
-                      </Mantine.Button>
-                    )}
-                  </div> */}
+                  {user.uuid !== "" && user.uuid !== data.user.uuid && (
+                    <div className="w-full flex flex-col gap-2 justify-center items-center">
+                      {follow ? (
+                        <Mantine.Button
+                          variant="outlined"
+                          size="small"
+                          onClick={handleFollow}
+                          className="w-32"
+                        >
+                          {t_ShowPost("unFollow")}
+                        </Mantine.Button>
+                      ) : (
+                        <Mantine.Button
+                          variant="contained"
+                          size="small"
+                          onClick={handleFollow}
+                          className="w-32"
+                        >
+                          {t_ShowPost("follow")}
+                        </Mantine.Button>
+                      )}
+                    </div>
+                  )}
                 </>
               ) : (
                 <Mantine.Skeleton height={70} />


### PR DESCRIPTION
# 概要
作品ページから投稿ユーザーへのフォロー・フォロー解除を実装しました。

## 実装項目
ログインユーザーとユーザーが一致しないとき
- [x] フォローボタンを押すとフォローできる
- [x] フォロー解除ボタンを押すとフォロー解除できる

## 挙動
ボタンが「フォロー」の状態だとターミナル上のリレーションシップテーブルが空に、
ボタンが「フォロー中」の状態だとターミナル上のリレーションシップテーブルに1件追加されています。
<img src="https://i.gyazo.com/a40dba5de6f78d5b47b6c4760d95ee06.gif" width="400px" />

## 懸念点
ヘッダーメニューは認証時のみ取得している関係で、ユーザーが利用している最中にフォロワーが増えてもヘッダーメニューのカウントが増えません。
また、同じくユーザーが利用している最中にフォローが増えてもキャッシュデータを使っている都合フォロワー一覧にフォロワーが出ない可能性が高いです。