### PR TITLE
【feature】フォロイー・フォロワー一覧 close #37 close #38

### DIFF
--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -301,14 +301,14 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
       {/* イラスト一覧 */}
       {(tabType.current === Tab.post || tabType.current === Tab.bookmark) && (
         <article className="mb-16">
-          <Users.IllustIndex uuid={uuid} url={url.current} />
+          <Users.IllustIndex url={url.current} />
         </article>
       )}
       {/* フォロー・フォロワー一覧 */}
       {(tabType.current === Tab.following ||
         tabType.current === Tab.follower) && (
         <article className="mb-16">
-          <Users.FollowIndex uuid={uuid} url={url.current} />
+          <Users.FollowIndex url={url.current} />
         </article>
       )}
     </>

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -5,16 +5,10 @@ import { FollowUser } from ".";
 import { GetFromAPI } from "@/lib";
 import useSWR from "swr";
 
-const feature = (url: string) => GetFromAPI(url).then((res) => res.data);
+const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
-export default function FollowIndex({
-  uuid,
-  url,
-}: {
-  uuid: string;
-  url: string;
-}) {
-  const { data, error } = useSWR(url, feature);
+export default function FollowIndex({ url }: { url: string }) {
+  const { data, error } = useSWR(url, fetcher);
 
   return (
     <section className="container my-2 m-auto">

--- a/front/src/components/features/users/illustIndex.tsx
+++ b/front/src/components/features/users/illustIndex.tsx
@@ -9,13 +9,7 @@ import { Skeleton } from "@mantine/core";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
-export default function IllustIndex({
-  uuid,
-  url,
-}: {
-  uuid: string;
-  url: string;
-}) {
+export default function IllustIndex({ url }: { url: string }) {
   const [illusts, setIllusts] = useState<IndexIllustData[]>([]);
   const { data, error } = useSWR(url, fetcher);
 


### PR DESCRIPTION
# 概要
ユーザーページのフォロー一覧・フォロワー一覧でバックと連携させました。

## 実装項目
- [x] ユーザーのフォロイー一覧が取得できること
   - [x] ユーザー名が取得できること
   - [x] アイコンが取得できること
- [x] ユーザーのフォロワー一覧が取得できること
   - [x] ユーザー名が取得できること
   - [x] アイコンが取得できること
- [x] フォロー一覧でフォローしているユーザーが表示される
- [x] フォロワー一覧でフォロワーが表示される

## 補足
フォロー一覧はログインユーザーと一致する場合のみ行事にしています

## 挙動
フォロワー一覧の画像は未ログイン時の見え方です
| フォロー一覧 | フォロワー一覧 |
| --- | --- |
| <img src="https://i.gyazo.com/42cc3262acc774191f53b011a9973b17.png" width="430px" /> | <img src="https://i.gyazo.com/cea4727fa6292fb7ee727e09ef0ea580.png" width="390px" /> |