### PR TITLE
【hotfix】フォロー一覧でユーザーアイコンがない時のエラー修正

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -78,7 +78,7 @@ class Api::V1::UsersController < Api::V1::BasesController
         user: {
           uuid: user.short_uuid,
           name: user.name,
-          avatar: user.profile.avatar.attached? ? url_for(user.profile.avatar) : nil,
+          avatar: user.profile&.avatar&.attached? ? url_for(user.profile.avatar) : nil,
         }
       }
     end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -89,9 +89,11 @@ class Api::V1::UsersController < Api::V1::BasesController
   def follower
     users = @user.followers.map do |user|
       {
-        uuid: user.short_uuid,
-        name: user.name,
-        avatar: user.profile.avatar.attached? ? url_for(user.profile.avatar) : nil,
+        user: {
+          uuid: user.short_uuid,
+          name: user.name,
+          avatar: user.profile&.avatar&.attached? ? url_for(user.profile.avatar) : nil,
+        }
       }
     end
 


### PR DESCRIPTION
# 概要
フォロー・フォロワー一覧で、フォロー・フォロワーユーザーにアイコンが設定されていない時にバックエンドでnilエラーが発生していたので修正しました。

## 補足
アイコンがないときはMantineのデフォルトアイコンが出るようになっています。
デフォルトアイコン画像は別途用意していません。