### PR TITLE
【feature】ユーザーページでフォロー・フォロー解除できるように追加 close #39

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -79,6 +79,7 @@ class Api::V1::UsersController < Api::V1::BasesController
           uuid: user.short_uuid,
           name: user.name,
           avatar: user.profile&.avatar&.attached? ? url_for(user.profile.avatar) : nil,
+          isFollowing: true
         }
       }
     end
@@ -93,6 +94,7 @@ class Api::V1::UsersController < Api::V1::BasesController
           uuid: user.short_uuid,
           name: user.name,
           avatar: user.profile&.avatar&.attached? ? url_for(user.profile.avatar) : nil,
+          isFavorite: current_api_v1_user&.following?(user)
         }
       }
     end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -92,7 +92,12 @@ class User < ActiveRecord::Base
   end
 
   def followed?(other_user_uuid)
-    relationship = following_relationships.find_by(followed_uuid: other_user_uuid)
+    relationship = follower_relationships.find_by(followed_uuid: other_user_uuid)
+    relationship.present?
+  end
+
+  def following?(other_user_uuid)
+    relationship = following_relationships.find_by(follower_uuid: other_user_uuid)
     relationship.present?
   end
 

--- a/front/src/app/[locale]/users/[uuid]/page.tsx
+++ b/front/src/app/[locale]/users/[uuid]/page.tsx
@@ -308,7 +308,7 @@ export default function UserPage({ params }: { params: { uuid: string } }) {
       {(tabType.current === Tab.following ||
         tabType.current === Tab.follower) && (
         <article className="mb-16">
-          <Users.FollowIndex url={url.current} />
+          <Users.FollowIndex url={url.current} userUuid={uuid} />
         </article>
       )}
     </>

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -7,12 +7,18 @@ import useSWR from "swr";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
-export default function FollowIndex({ url }: { url: string }) {
+export default function FollowIndex({
+  url,
+  userUuid,
+}: {
+  url: string;
+  userUuid: string;
+}) {
   const { data, error } = useSWR(url, fetcher);
 
   return (
     <section className="container my-2 m-auto">
-      <div className="grid grid-cols-4 md:grid-cols-8 gap-x-2 md:gap-x-0 gap-y-8 mx-2 justify-center items-center">
+      <div className="grid grid-cols-4 md:grid-cols-8 gap-x-2 gap-y-8 mx-2 justify-center items-center">
         {data === undefined ? (
           <>
             {Array.from({ length: 10 }, (_, index) => (
@@ -22,7 +28,9 @@ export default function FollowIndex({ url }: { url: string }) {
         ) : (
           data.users?.map(
             ({ user, i }: { user: IIndexFollowData; i: number }) => (
-              <FollowUser key={i} user={user} />
+              <>
+                <FollowUser key={i} followUser={user} userUuid={userUuid} />
+              </>
             )
           )
         )}

--- a/front/src/components/features/users/followUser.tsx
+++ b/front/src/components/features/users/followUser.tsx
@@ -1,20 +1,61 @@
-import { Link } from "@/lib";
+"use client";
+
+import { Delete2API, Link, Post2API } from "@/lib";
+import { userState } from "@/recoilState";
 import { RouterPath } from "@/settings";
-import { IIndexFollowData } from "@/types";
+import { IIndexFollowData, IUser } from "@/types";
 import * as Mantine from "@mantine/core";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useRecoilState } from "recoil";
 
 export default function FollowUser({
-  user = {
+  followUser = {
     uuid: "",
     name: "",
     avatar: "",
+    isFollowing: false,
   },
+  userUuid,
 }: {
-  user?: IIndexFollowData;
+  followUser?: IIndexFollowData;
+  userUuid?: string;
 }) {
+  const [user, setUser] = useRecoilState(userState);
+  const [follow, setFollow] = useState(followUser.isFollowing);
+  const t_ShowPost = useTranslations("ShowPost");
+
+  const handleFollow = async () => {
+    try {
+      if (follow) {
+        const res = await Delete2API(`users/${followUser.uuid}/relationship`);
+        if (res.status === 204) {
+          setFollow(false);
+          setUser((prevUser: IUser) => ({
+            ...prevUser,
+            following_count: prevUser.following_count - 1,
+          }));
+        }
+      } else {
+        const res = await Post2API(`users/${followUser.uuid}/relationship`, {
+          user_uuid: followUser.uuid,
+        });
+        if (res.status === 201) {
+          setFollow(true);
+          setUser((prevUser: IUser) => ({
+            ...prevUser,
+            following_count: prevUser.following_count + 1,
+          }));
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <div>
-      {user.uuid === "" ? (
+      {followUser.uuid === "" ? (
         <>
           <div className="flex flex-col justify-center items-center gap-2">
             <Mantine.Skeleton width={100} height={100} radius="100%" />
@@ -22,18 +63,43 @@ export default function FollowUser({
           </div>
         </>
       ) : (
-        <Link
-          href={RouterPath.users(user.uuid)}
-          className="flex flex-col justify-center items-center"
-        >
-          <Mantine.Avatar
-            variant="default"
-            size="xl"
-            src={user.avatar}
-            alt="avatar"
-          />
-          <p>{user.name}</p>
-        </Link>
+        <>
+          <Link
+            href={RouterPath.users(followUser.uuid)}
+            className="flex flex-col justify-center items-center"
+          >
+            <Mantine.Avatar
+              variant="default"
+              size="xl"
+              src={followUser.avatar}
+              alt="avatar"
+            />
+            <p>{followUser.name}</p>
+          </Link>
+          {user.uuid === userUuid && (
+            <div className="w-full flex flex-col gap-2 justify-center items-center">
+              {follow ? (
+                <Mantine.Button
+                  variant="outline"
+                  size="xs"
+                  onClick={handleFollow}
+                  className="w-full"
+                >
+                  {t_ShowPost("unFollow")}
+                </Mantine.Button>
+              ) : (
+                <Mantine.Button
+                  variant="contained"
+                  size="xs"
+                  onClick={handleFollow}
+                  className="w-full"
+                >
+                  {t_ShowPost("follow")}
+                </Mantine.Button>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -102,4 +102,5 @@ export interface IIndexFollowData {
   uuid: string;
   name: string;
   avatar: string;
+  isFollowing: boolean;
 }


### PR DESCRIPTION
# 概要
ユーザーページでフォロー・フォロー解除ができるようにしました。

## 実装項目
- [x] 解除ボタンを押したらバックにフォロワー削除を送る
- [ ] フォロワーが削除できたらフロントの一覧からスムースレスに表示されなくなる
   ⇨ 間違えて解除した時に困るので、遷移などしたら非表示にされるようにしました

## 挙動
<img src="https://i.gyazo.com/13926761164a7c3c290cf49980f7214f.gif" width="400px" />