### PR TITLE
【hotfix】不要なユニークのマイグレーションを削除

### DIFF
--- a/back/db/migrate/20240606053842_add_password_reset.rb
+++ b/back/db/migrate/20240606053842_add_password_reset.rb
@@ -5,6 +5,5 @@ class AddPasswordReset < ActiveRecord::Migration[7.1]
     add_column :users, :allow_password_change, :boolean, default: false
     add_index :users, :reset_password_token, unique: true
     add_index :users, :reset_password_sent_at, unique: true
-    add_index :users, :allow_password_change, unique: true
   end
 end

--- a/back/db/migrate/20240607044816_remove_unique_index_from_allow_password_change_on_users.rb
+++ b/back/db/migrate/20240607044816_remove_unique_index_from_allow_password_change_on_users.rb
@@ -1,5 +1,0 @@
-class RemoveUniqueIndexFromAllowPasswordChangeOnUsers < ActiveRecord::Migration[7.1]
-  def change
-    remove_index :users, :allow_password_change
-  end
-end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_07_044816) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_07_044816) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.boolean "allow_password_change", default: false
+    t.index ["allow_password_change"], name: "index_users_on_allow_password_change"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_sent_at"], name: "index_users_on_reset_password_sent_at", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 概要
真偽判定のカラムにユニーク属性がついていたが不要なので削除対応します。
ローカルでは問題ないのですが、本環境でデプロイに失敗しているため過去のマイグレーションファイルを操作しています。

## 懸念事項
これで本番でも問題なく動くのかどうか…