### PR TITLE
【fix】ホワイトリストURLの設定

### DIFF
--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -23,14 +23,14 @@ class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCal
           sign_in(user)
           save_to_redirect(user, token_hash, client_id, token, expiry)
         else
-          redirect_to "#{ENV['FRONT_URL']}/?status=error", allow_other_host: true
+          redirect_to "#{ENV['FRONT_URL']}/?status=error"
         end
       end
     end
   end
 
   def failure
-    redirect_to "#{ENV['FRONT_URL']}/ja/auth-failure", allow_other_host: true
+    redirect_to "#{ENV['FRONT_URL']}/ja/auth-failure"
   end
 
   private
@@ -45,7 +45,7 @@ class Api::V1::Auth::OmniauthCallbacksController <  DeviseTokenAuth::OmniauthCal
     if user.save
       redirect_to "#{ENV['FRONT_URL']}/ja?uid=#{user.uid}&token=#{token}&client=#{client_id}&expiry=#{expiry}", allow_other_host: true
     else
-      redirect_to "#{ENV['FRONT_URL']}/ja?status=error", allow_other_host: true
+      redirect_to "#{ENV['FRONT_URL']}/ja?status=error"
     end
   end
 

--- a/back/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/back/app/controllers/api/v1/auth/passwords_controller.rb
@@ -25,34 +25,6 @@ class Api::V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
     end
   end
 
-  def edit
-    @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
-
-    if @resource && @resource.reset_password_period_valid?
-      token = @resource.create_token unless require_client_password_reset_token?
-
-      @resource.skip_confirmation! if confirmable_enabled? && !@resource.confirmed_at
-      @resource.allow_password_change = true if recoverable_enabled?
-
-      @resource.save!
-
-      yield @resource if block_given?
-
-      if require_client_password_reset_token?
-        redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token]), allow_other_host: true
-      else
-        if DeviseTokenAuth.cookie_enabled
-          set_token_in_cookie(@resource, token)
-        end
-        redirect_header_options = { reset_password: true }
-        redirect_headers = build_redirect_headers(token.token, token.client, redirect_header_options)
-        redirect_to @resource.build_auth_url(@redirect_url, redirect_headers), allow_other_host: true
-      end
-    else
-      render_edit_error
-    end
-  end
-
   def update
     if require_client_password_reset_token? && resource_params[:reset_password_token]
       @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -67,4 +67,7 @@ DeviseTokenAuth.setup do |config|
 
   # リセットパスワードのメール送信時のリダイレクト先
   config.default_password_reset_url = "#{ENV['FRONT_URL']}/ja/reset-password"
+
+  # リダイレクトのホワイトリスト
+  config.redirect_whitelist = ["#{ENV['FRONT_URL']}"]
 end


### PR DESCRIPTION
# 概要
リダイレクトの際に`allow_other_host: true`をつけていましたが、ホワイトリストを設定したほうが安全性が高そうなのでホワイトリストの設定に切り替えました。

## 補足
ローカルではドメインがおなじになってしまい確認ができないため、本環境で動作確認をします。