### PR TITLE
【fix】パスワードリセットにおけるホワイトリストのリダイレクトURLを設定

### DIFF
--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -69,5 +69,9 @@ DeviseTokenAuth.setup do |config|
   config.default_password_reset_url = "#{ENV['FRONT_URL']}/ja/reset-password"
 
   # リダイレクトのホワイトリスト
-  config.redirect_whitelist = ["#{ENV['FRONT_URL']}"]
+  config.redirect_whitelist = [
+    "#{ENV['FRONT_URL']}",
+    "#{ENV['FRONT_URL']}/ja/reset-password",
+    "#{ENV['FRONT_URL']}/en/reset-password"
+  ]
 end


### PR DESCRIPTION
# 概要
パスワードリセットにおけるリダイレクトでホワイトリストURLを設定しました。

## 補足
URLはそれぞれ設定しないといけないようです。
ワイルドカードの利用はできないようです。言語が追加されたら都度都度対応が必要です。