### PR TITLE
【feature】バックでコメント機能の追加 close #59

### DIFF
--- a/back/app/controllers/api/v1/comments_controller.rb
+++ b/back/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,57 @@
+class Api::V1::CommentsController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[index]
+  before_action :set_post
+
+  def index
+    comments = @post.comments.order(created_at: :desc).map do |comment|
+      {
+        id: comment.id,
+        text: comment.text,
+      }
+    end
+    render json: { comments: comments }, status: :ok
+  end
+
+  def create
+    Comment.transaction do
+      comment = Comment.new(comment_params)
+      comment.user = current_api_v1_user
+      @post.comments << comment
+      if @post.save
+        render json: { message: 'Comment created' }, status: :created
+      else
+        render json: { message: 'Comment not created' }, status: :internal_server_error
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+  def destroy
+    Comment.transaction do
+      comment = @post.comments.find_by(id: params[:id])
+      if comment.nil?
+        render json: { message: 'Comment not found' }, status: :not_found and return
+      end
+
+      if comment.destroy
+        render json: { message: 'Comment deleted' }, status: :ok
+      else
+        render json: { message: 'Comment not deleted' }, status: :internal_server_error
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:text)
+  end
+
+  def set_post
+    @post = Post.find_by_short_uuid(params[:post_id])
+    if @post.nil?
+      render json: { message: 'Post not found' }, status: 404
+    end
+  end
+end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user, foreign_key: :user_uuid, primary_key: :uuid
+  has_many :post_comments, dependent: :destroy
+  has_many :posts, foreign_key: :post_uuid, through: :post_comments
+  validates :text, presence: true, length: { maximum: 500 }
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -27,6 +27,8 @@ class Post < ApplicationRecord
   has_many :favorites, foreign_key: :post_uuid, dependent: :destroy
   has_many :bookmarks, foreign_key: :post_uuid, dependent: :destroy
   has_many :post_game_systems, foreign_key: :post_uuid, dependent: :destroy
+  has_many :post_comments, foreign_key: :post_uuid, dependent: :destroy
+  has_many :comments, through: :post_comments
 
   validates :title, presence: true, length: { maximum: 20 }
   validates :caption, length: { maximum: 10_000 }

--- a/back/app/models/post_comment.rb
+++ b/back/app/models/post_comment.rb
@@ -1,0 +1,4 @@
+class PostComment < ApplicationRecord
+  belongs_to :post, foreign_key: :post_uuid, primary_key: :uuid
+  belongs_to :comment
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ActiveRecord::Base
   has_many :user_notices, foreign_key: :user_uuid, dependent: :destroy
   has_many :notices, through: :user_notices
   has_many :posts, foreign_key: :user_uuid, dependent: :destroy
+  has_many :post_comments, foreign_key: :user_uuid, dependent: :destroy
+  has_many :comments, through: :post_comments
 
   # フォローしている人とフォローされている人を取得するためのアソシエーション
   has_many :following_relationships, class_name: 'Relationship', foreign_key: 'follower_uuid', dependent: :destroy, inverse_of: :follower

--- a/back/config/locales/ja.yml
+++ b/back/config/locales/ja.yml
@@ -1,5 +1,10 @@
 ja:
   activerecord:
+    models:
+      comment: コメント
+    attributes:
+      comment:
+        text: 本文
     errors:
       models:
         post:
@@ -12,3 +17,15 @@ ja:
               required: "投稿タイプを設定してください"
             post_game_systems:
               invalid: "無効なゲームシステムです"
+        comment:
+          attributes:
+            text:
+              blank: "本文を入力してください"
+              too_long: "本文は%{count}文字以内で入力してください"
+              record_invalid: "バリデーションに失敗しました: %{errors}"
+            user:
+              required: "ユーザーを設定してください"
+      messages:
+        blank: "本文を入力してください"
+        too_long: "本文は%{count}文字以内で入力してください"
+        record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       }
       resource :account, only: %i[show update]
       resource :notice, only: %i[update]
-      resources :posts, only: %i[index show create edit update destroy]
+      resources :posts do
+        resources :comments, only: %i[index create update destroy]
+      end
       resources :illusts, only: %i[index]
       resources :tags, only: %i[index create]
       resources :synalios, only: %i[index]

--- a/back/db/migrate/20240610042515_create_comments.rb
+++ b/back/db/migrate/20240610042515_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.text :text, null: false, default: '', limit: 500
+      t.uuid :user_uuid, null: false
+      t.timestamps
+    end
+    add_foreign_key :comments, :users, column: :user_uuid, primary_key: :uuid
+  end
+end

--- a/back/db/migrate/20240610042529_create_post_comments.rb
+++ b/back/db/migrate/20240610042529_create_post_comments.rb
@@ -1,0 +1,10 @@
+class CreatePostComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_comments do |t|
+      t.uuid :post_uuid, null: false
+      t.references :comment, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_foreign_key :post_comments, :posts, column: :post_uuid, primary_key: :uuid
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_10_042529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -60,6 +60,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
     t.index ["user_uuid", "post_uuid"], name: "index_bookmarks_on_user_uuid_and_post_uuid", unique: true
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "text", default: "", null: false
+    t.uuid "user_uuid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "favorites", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -99,6 +106,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
     t.boolean "follower", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "post_comments", force: :cascade do |t|
+    t.uuid "post_uuid", null: false
+    t.bigint "comment_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id"], name: "index_post_comments_on_comment_id"
   end
 
   create_table "post_game_systems", force: :cascade do |t|
@@ -209,10 +224,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_053842) do
   add_foreign_key "authentications", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "bookmarks", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "bookmarks", "users", column: "user_uuid", primary_key: "uuid"
+  add_foreign_key "comments", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "favorites", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "favorites", "users", column: "user_uuid", primary_key: "uuid"
   add_foreign_key "illust_attachments", "illusts"
   add_foreign_key "links", "users", column: "user_uuid", primary_key: "uuid"
+  add_foreign_key "post_comments", "comments"
+  add_foreign_key "post_comments", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_game_systems", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "posts", column: "post_uuid", primary_key: "uuid"
   add_foreign_key "post_synalios", "synalios"


### PR DESCRIPTION
# 概要
コメント機能の追加をバックエンド側で行いました。

## 実装項目
- [x] コメントとユーザーidを送信するとコメントテーブルが追加され、コメント中間テーブルも更新される
   ⇨ ログインのみの機能なのでユーザーidの送信は不要。変わりにトークンをrequestに含める
- [x] コメントidをdeleteで送信すると、コメントが削除される
- [ ] コメントの追加・削除は非同期で行われる
   ⇨ フロントで実装

## 挙動
① コメント一覧
<img src="https://i.gyazo.com/eb6b823e62851a99a21771ece1179423.png" width="400px" />

②コメント追加
<img src="https://i.gyazo.com/ceec5d31a8fccf60e9fafc282438cb07.png" width="400px" />

③コメント削除
<img src="https://i.gyazo.com/a2aca3cae01d0202a847ccb2d6837660.png" width="400px" />

④コメント一覧　新しく追加され、既存のコメントが削除されている
<img src="https://i.gyazo.com/ae5f63d3d7806e9c7d4dd18129bd3b5e.png" width="400px" />