### PR TITLE
【fix】N+1問題修正

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   before_action :set_post, only: %i[update destroy]
 
   def index
-    posts = Post.includes(:postable, :user, postable: { illust_attachments: :image }).where(publish_state: 'all_publish').order(published_at: :desc).limit(20)
+    posts = Post.includes(:postable, :user, postable: :illust_attachments).where(publish_state: 'all_publish').order(published_at: :desc).limit(20)
     posts_json = posts.map do |post|
       content = nil
       if post.illust?
@@ -23,7 +23,7 @@ class Api::V1::PostsController < Api::V1::BasesController
         raise ActiveRecord::RecordInvalid
       end
 
-      post = Post.includes(:postable, :tags, :synalios, :user, postable: { illust_attachments: :image }).find_by_short_uuid(params[:id])
+      post = Post.includes(:postable, :tags, :synalios, :user, postable: :illust_attachments).find_by_short_uuid(params[:id])
 
       if post.nil? || !post.publishable?(current_api_v1_user)
         raise ActiveRecord::RecordNotFound
@@ -91,7 +91,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   end
 
   def edit
-    post = current_api_v1_user.posts.includes(:postable, :tags, :synalios, postable: { illust_attachments: :image }).find_by_short_uuid(params[:id])
+    post = current_api_v1_user.posts.includes(:postable, :tags, :synalios, postable: :illust_attachments).find_by_short_uuid(params[:id])
 
     if post.nil? || post.postable.nil?
       render json: { error: 'Not Found' }, status: :not_found and return


### PR DESCRIPTION
# 概要
イラスト取得周りでN+1問題が発生していたので修正しました。

## 気づいた理由
SentryでN+1の発生が通告されいました。

## 修正箇所
画像の複数枚投稿と並び順の追加に伴い、post - illust - illust_attachmentとインクルードするものが増えていました。
それを追加し忘れていたことに寄る発生のようです。
includesに含めることで修正しました。