### PR TITLE
【hotfix】フォロワー取得データでいいねの名前で取得していたので修正 close #291

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -94,7 +94,7 @@ class Api::V1::UsersController < Api::V1::BasesController
           uuid: user.short_uuid,
           name: user.name,
           avatar: user.profile&.avatar&.attached? ? url_for(user.profile.avatar) : nil,
-          isFavorite: current_api_v1_user&.following?(user)
+          isFollowing: current_api_v1_user&.following?(user)
         }
       }
     end


### PR DESCRIPTION
フォロワー取得の情報データで、ログインユーザーがフォローしているかのフラグを`isFavorite`という名前で取得していたので修正しました。