### PR TITLE
【fix】ログインユーザーと表示ユーザーが異なる場合はフォロイーを表示しないよう修正 close #239

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -73,7 +73,11 @@ class Api::V1::UsersController < Api::V1::BasesController
   end
 
   def following
-    users = @user.following.map do |user|
+    if(current_api_v1_user == nil || current_api_v1_user.uuid != @user.uuid)
+      render json: { error: 'Unauthorized' }, status: :unauthorized and return
+    end
+
+    users = current_api_v1_user.following.map do |user|
       {
         user: {
           uuid: user.short_uuid,

--- a/front/src/app/[locale]/illusts/[uuid]/page.tsx
+++ b/front/src/app/[locale]/illusts/[uuid]/page.tsx
@@ -14,11 +14,7 @@ import { Carousel } from "@mantine/carousel";
 import "@mantine/carousel/styles.css";
 import { Comments } from "@/components/features/illusts";
 
-const fetcherIllust = (url: string) =>
-  Lib.GetFromAPI(url).then((res) => res.data);
-
-const fecherFollow = (url: string) =>
-  Lib.GetFromAPI(url).then((res) => res.data);
+const fetcher = (url: string) => Lib.GetFromAPI(url).then((res) => res.data);
 
 export default function IllustPage({
   params: { uuid },
@@ -26,10 +22,10 @@ export default function IllustPage({
   params: { uuid: string };
 }) {
   const [user, setUser] = useRecoilState(RecoilState.userState);
-  const { data, error } = useSWR(`/posts/${uuid}`, fetcherIllust);
+  const { data, error } = useSWR(`/posts/${uuid}`, fetcher);
   const { data: followData, error: followError } = useSWR(
     data?.user?.uuid ? `users/${data.user.uuid}/relationship` : "",
-    fecherFollow
+    fetcher
   );
   const [expansionMode, setExpansionMode] = useState(false);
   const [openCaption, setOpenCaption] = useState(false);

--- a/front/src/components/features/users/followIndex.tsx
+++ b/front/src/components/features/users/followIndex.tsx
@@ -2,8 +2,10 @@
 
 import { IIndexFollowData, Tab } from "@/types";
 import { FollowUser } from ".";
-import { GetFromAPI } from "@/lib";
+import { GetFromAPI, useRouter } from "@/lib";
 import useSWR from "swr";
+import { useEffect } from "react";
+import { RouterPath } from "@/settings";
 
 const fetcher = (url: string) => GetFromAPI(url).then((res) => res.data);
 
@@ -15,6 +17,18 @@ export default function FollowIndex({
   userUuid: string;
 }) {
   const { data, error } = useSWR(url, fetcher);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (error) {
+      if (error.response.status === 401) {
+        router.push(RouterPath.follower(userUuid));
+      } else {
+        router.push(RouterPath.error);
+      }
+      return;
+    }
+  }, [error]);
 
   return (
     <section className="container my-2 m-auto">


### PR DESCRIPTION
ログインユーザー以外でもフォローしている人を見ることができてしまっていたので、修正しました。