### PR TITLE
【fix】テストフレームワークをRSpecに設定

### DIFF
--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -30,9 +30,9 @@ module App
     config.api_only = true
 
     config.generators do |g|
+      g.test_framework :rspec
       g.skip_routes true
       g.helper false
-      g.test_framework nil
     end
 
     config.time_zone = 'Tokyo'


### PR DESCRIPTION
# 概要
Railsアプリのテストフレームワークの設定がなかったのでRSpecに設定しました。