### PR TITLE
【feature】IllustAttachmentのモデルSpecを作成 close #280 resolve #278 #281

### DIFF
--- a/back/app/models/illust_attachment.rb
+++ b/back/app/models/illust_attachment.rb
@@ -9,7 +9,9 @@
 #  updated_at :datetime         not null
 #
 class IllustAttachment < ApplicationRecord
+  include AttachmentValidations
   belongs_to :illust
-  has_one_attached :image
+  has_validated_attachment :image
+  validates :image, presence: true
   validates :position, presence: true
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -30,6 +30,7 @@ class Post < ApplicationRecord
   has_many :post_comments, foreign_key: :post_uuid, dependent: :destroy
   has_many :comments, through: :post_comments
 
+  validates :postable_type, presence: true
   validates :title, presence: true, length: { maximum: 20 }
   validates :caption, length: { maximum: 10_000 }
   enum publish_state: { draft: 0, all_publish: 1, only_url: 2, only_follower: 3, private_publish:4 }

--- a/back/config/locales/ja.yml
+++ b/back/config/locales/ja.yml
@@ -17,6 +17,14 @@ ja:
               required: "投稿タイプを設定してください"
             post_game_systems:
               invalid: "無効なゲームシステムです"
+        illust_attachment:
+          attributes:
+            image:
+              blank: "イラストを選択してください"
+              too_large: "イラストは%{max_size}MB以下のファイルを選択してください"
+              invalid_content_type: "イラスト形式は%{content_type}のみ対応しています"
+            position:
+              blank: "イラストの表示順を設定してください"
         tag:
           attributes:
             name:
@@ -42,15 +50,20 @@ ja:
         user:
           attributes:
             name:
+              blank: "ユーザー名を入力してください"
               taken: "が既に使用されています"
             email:
               taken: "が既に使用されています"
+              blank: "メールアドレスを入力してください"
+              invalid: "メールアドレスの形式が正しくありません"
             password:
-              record_invalid: "バリデーションに失敗しました: %{errors}"
+              too_short: "パスワードは%{count}文字以上で入力してください"
+              blank: "パスワードを入力してください"
             uid:
-              record_invalid: "バリデーションに失敗しました: %{errors}"
+              blank: "ユーザーIDを入力してください"
+              taken: "が既に使用されています"
             provider:
-              record_invalid: "バリデーションに失敗しました: %{errors}"
+              blank: "プロバイダーを入力してください"
         profile:
           attributes:
             text:
@@ -68,8 +81,3 @@ ja:
               blank: "リンクタイプを選択してください"
             content:
               blank: "URLを入力してください"
-      messages:
-        blank: "を入力してください"
-        too_long: "は%{count}文字以内で入力してください"
-        too_short: "は%{count}文字以上で入力してください"
-        record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/back/spec/factories/illust_attachments.rb
+++ b/back/spec/factories/illust_attachments.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :illust_attachment do
+    association :illust
+    sequence(:position) { |n| n }
+    after(:create) do |illust_attachment|
+      image_blob = FactoryBotHelpers.dummy_image('dummy.png')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                    filename: SecureRandom.uuid,
+                                    content_type: 'image/webp')
+    end
+  end
+end

--- a/back/spec/factories/illusts.rb
+++ b/back/spec/factories/illusts.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :illust do
+    trait(:with_image_one) do
+      after(:create) do |illust|
+        illust.illust_attachments << create(:illust_attachment)
+      end
+    end
+
+    MAX_IMAGES_COUNT = 12
+    trait(:with_images_twelve) do |illust|
+      after(:create) do |illust|
+        MAX_IMAGES_COUNT.times do
+          illust.illust_attachments << create(:illust_attachment)
+        end
+      end
+    end
+  end
+end

--- a/back/spec/factories/posts.rb
+++ b/back/spec/factories/posts.rb
@@ -1,0 +1,39 @@
+FactoryBot.define do
+  factory :post, class: 'Post' do
+    association :user
+    sequence(:title) { |n| "title#{n}" }
+    caption { 'caption' }
+
+    states = [:draft, :all_publish, :only_url, :only_follower, :private_publish]
+    states.each do |state|
+      trait(state) { publish_state { Post.publish_states[state] } }
+    end
+
+    trait :with_tags do
+      after(:create) do |post|
+        post.tags << create(:tag)
+      end
+    end
+
+    trait :with_synalios do
+      after(:create) do |post|
+        post.synalios << create(:synalio)
+      end
+    end
+
+    trait :with_illust do
+      postable { create(:illust) }
+      postable_type { 'Illust' }
+    end
+
+    trait :with_illust_one do
+      postable { create(:illust, :with_image_one) }
+      postable_type { 'Illust' }
+    end
+
+    trait :with_illust_twelve do
+      postable { create(:illust, :with_images_twelve) }
+      postable_type { 'Illust' }
+    end
+  end
+end

--- a/back/spec/models/illust_attachment_spec.rb
+++ b/back/spec/models/illust_attachment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IllustAttachment, type: :model do
+  
+end

--- a/back/spec/models/illust_attachment_spec.rb
+++ b/back/spec/models/illust_attachment_spec.rb
@@ -1,5 +1,75 @@
 require 'rails_helper'
 
 RSpec.describe IllustAttachment, type: :model do
-  
+  let!(:post){ create(:illust) }
+
+  describe 'イラストバリデーション' do
+    it 'イラストが存在する場合、有効であること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      image_blob = FactoryBotHelpers.dummy_image('dummy.png')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                      filename: SecureRandom.uuid,
+                                      content_type: 'image/webp')
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to be_empty
+    end
+
+    it 'イラストが存在しない場合、無効であること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to include('イラストを選択してください')
+    end
+
+    it 'イラストのサイズが10MB以下の場合、有効であること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      image_blob = FactoryBotHelpers.dummy_image('dummy.png')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                      filename: SecureRandom.uuid,
+                                      content_type: 'image/webp')
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to be_empty
+    end
+
+    it 'イラストのサイズが10MBを超える場合、無効であること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      image_blob = FactoryBotHelpers.dummy_image('over_10_mb.jpg')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                      filename: SecureRandom.uuid,
+                                      content_type: 'image/webp')
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to include('イラストは10MB以下のファイルを選択してください')
+    end
+
+    it 'イラストの拡張子がwebpで保存できること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      image_blob = FactoryBotHelpers.dummy_image('dummy.png', 'webp')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                      filename: SecureRandom.uuid,
+                                      content_type: 'image/webp')
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to be_empty
+    end
+
+    it 'イラストの拡張子がwebp以外の場合、無効であること' do
+      illust_attachment = build(:illust_attachment, illust: post)
+      image_blob = FactoryBotHelpers.dummy_image('dummy.png', 'jpg')
+      illust_attachment.image.attach(io: StringIO.new(image_blob),
+                                      filename: SecureRandom.uuid,
+                                      content_type: 'image/jpg')
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:image]).to include('イラスト形式はwebpのみ対応しています')
+    end
+
+    it 'イラストの表示位置がある場合、保存できること' do
+      illust_attachment = build(:illust_attachment, illust: post, position: 1)
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:position]).to be_empty
+    end
+
+    it 'イラストの表示位置がない場合、無効であること' do
+      illust_attachment = build(:illust_attachment, illust: post, position: nil)
+      illust_attachment.valid?
+      expect(illust_attachment.errors[:position]).to include('イラストの表示順を設定してください')
+    end
+  end
 end

--- a/back/spec/models/illust_spec.rb
+++ b/back/spec/models/illust_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Illust, type: :model do
+end

--- a/back/spec/models/post_spec.rb
+++ b/back/spec/models/post_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+end


### PR DESCRIPTION
# 概要
IllustAttachmentのモデルSpecを作成しました
合わせてPostモデルとIllustモデルの一部を実装しました。

## テストケース
- イラスト
   - あれば有効
   - なければ無効
   - サイズが10MB以下なら有効
   - サイズが10MBより上なら無効
   - webpなら有効
   - webp以外なら無効
   - 表示順の設定があれば有効
   - 表示順の設定ながければ無効  